### PR TITLE
Rename and enforce same size for newListAfterFlow

### DIFF
--- a/application/base/main/default/classes/TriggerActionFlow.cls
+++ b/application/base/main/default/classes/TriggerActionFlow.cls
@@ -28,6 +28,8 @@ public class TriggerActionFlow implements TriggerAction.BeforeInsert, TriggerAct
 	private static final String OLD_RECORD_NOT_FOUND = 'An old version of the record cannot be identified in the oldList';
 	@testVisible
 	private static final String INVALID_REQUEST = 'You can only pass one getOldRecordRequest into TriggerActionFlow.getOldRecord()';
+	@testVisible
+	private static final String NEW_LIST_AFTER_FLOW_NOT_POPULATED_CORRECTLY = 'You must pass ALL records back to the newListAfterFlow in order to apply values to record before insert/update';
 
 	@InvocableMethod
 	public static List<sObject> getOldRecord(List<OldRecordRequest> request) {
@@ -152,7 +154,17 @@ public class TriggerActionFlow implements TriggerAction.BeforeInsert, TriggerAct
 		List<sObject> newList,
 		List<sObject> newListAfterFlow
 	) {
-		if (!newList.isEmpty()) {
+		if (
+			newList != null &&
+			!newList.isEmpty() &&
+			newListAfterFlow != null &&
+			!newListAfterFlow.isEmpty()
+		) {
+			if (newList.size() != newListAfterFlow.size()) {
+				throw new TriggerActionFlowException(
+					NEW_LIST_AFTER_FLOW_NOT_POPULATED_CORRECTLY
+				);
+			}
 			List<String> editableFields = new List<String>();
 			for (
 				Schema.SObjectField fieldRef : newList[0]

--- a/application/opportunity-automation/main/default/customMetadata/Trigger_Action.ta_Opportunity_Queries_BI.md-meta.xml
+++ b/application/opportunity-automation/main/default/customMetadata/Trigger_Action.ta_Opportunity_Queries_BI.md-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CustomMetadata xmlns="http://soap.sforce.com/2006/04/metadata" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-    <label>OpportunityTriggerQueries_BI</label>
+    <label>ta_Opportunity_Queries_BI</label>
     <protected>false</protected>
     <values>
         <field>After_Delete__c</field>


### PR DESCRIPTION
Allows for the execution of a flow in the before context without necessarily populating the `newListAfterFlow` variable

- [ x] Tests pass
- [ x] Appropriate changes to README are included in PR