### PR TITLE
Fix recursion check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project is meant to demonstrate an Apex Trigger Framework which is built wi
 In order to use this trigger framework, we start with the `MetadataTriggerHandler` class which is included in this project.
 
 ```java
-Trigger OppportunityTrigger on Opportunity (before insert, after insert, before update, after update, before delete, after delete, after undelete) {
+Trigger OpportunityTrigger on Opportunity (before insert, after insert, before update, after update, before delete, after delete, after undelete) {
   new MetadataTriggerHandler().run();
 }
 ```
@@ -105,7 +105,7 @@ To enable this flow, simply insert a trigger action record with Apex Class Name 
 
 ## Recursion Prevention
 
-Use the `TriggerBase.idsProcessedBeforeUpdate` and `TriggerBase.idsProcessedAfterUpdate` to prevent recursively processing the same record(s).
+Use the `TriggerBase.idsToNumberOfTimesSeenBeforeUpdate` and `TriggerBase.idsToNumberOfTimesSeenAfterUpdate` to prevent recursively processing the same record(s).
 
 ```java
 public class ta_Opportunity_RecalculateCategory implements TriggerAction.AfterUpdate {
@@ -115,7 +115,7 @@ public class ta_Opportunity_RecalculateCategory implements TriggerAction.AfterUp
     List<Opportunity> oppsToBeUpdated = new List<Opportunity>();
     for (Opportunity opp : newList) {
       if (
-        !TriggerBase.idsProcessedAfterUpdate.contains(opp.id) &&
+        TriggerBase.idsToNumberOfTimesSeenAfterUpdate.get(opp.id) == 1 &&
         opp.StageName != oldMap.get(opp.id).StageName
       ) {
         oppsToBeUpdated.add(opp);

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -76,7 +76,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		checkFlowName();
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
 		for (sObject record : newList) {
-			if (!TriggerBase.idsProcessedBeforeUpdate.contains(record.id)) {
+			if (TriggerBase.idsToNumberOfTimesSeenBeforeUpdate.get(record.id) == 1) {
 				recordsNotYetProcessed.add(record);
 			}
 		}
@@ -95,7 +95,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		checkFlowName();
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
 		for (sObject record : newList) {
-			if (!TriggerBase.idsProcessedAfterUpdate.contains(record.id)) {
+			if (TriggerBase.idsToNumberOfTimesSeenAfterUpdate.get(record.id) == 1) {
 				recordsNotYetProcessed.add(record);
 			}
 		}

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls
@@ -20,20 +20,26 @@ public inherited sharing virtual class TriggerBase {
 	@TestVisible
 	private static Set<String> bypassedObjects;
 	@TestVisible
-	public static Set<Id> idsProcessedBeforeUpdate { get; private set; }
+	public static Map<Id, Integer> idsToNumberOfTimesSeenBeforeUpdate {
+		get;
+		private set;
+	}
 	@TestVisible
-	public static Set<Id> idsProcessedAfterUpdate { get; private set; }
+	public static Map<Id, Integer> idsToNumberOfTimesSeenAfterUpdate {
+		get;
+		private set;
+	}
 
 	static {
 		bypassedObjects = new Set<String>();
-		idsProcessedBeforeUpdate = new Set<Id>();
-		idsProcessedAfterUpdate = new Set<Id>();
+		idsToNumberOfTimesSeenBeforeUpdate = new Map<Id, Integer>();
+		idsToNumberOfTimesSeenAfterUpdate = new Map<Id, Integer>();
 	}
 
 	public void run() {
-		if (!validateRun())
+		if (!validateRun()) {
 			return;
-
+		}
 		if (
 			this.context == System.TriggerOperation.BEFORE_INSERT &&
 			this instanceof TriggerAction.BeforeInsert
@@ -60,6 +66,16 @@ public inherited sharing virtual class TriggerBase {
 			this.context == System.TriggerOperation.BEFORE_UPDATE &&
 			this instanceof TriggerAction.BeforeUpdate
 		) {
+			for (SObject obj : triggerNew) {
+				if (!idsToNumberOfTimesSeenBeforeUpdate.containsKey(obj.id)) {
+					idsToNumberOfTimesSeenBeforeUpdate.put(obj.id, 1);
+				} else {
+					idsToNumberOfTimesSeenBeforeUpdate.put(
+						obj.id,
+						idsToNumberOfTimesSeenBeforeUpdate.get(obj.id) + 1
+					);
+				}
+			}
 			try {
 				((TriggerAction.BeforeUpdate) this)
 					.beforeUpdate(triggerNew, triggerOld);
@@ -68,22 +84,26 @@ public inherited sharing virtual class TriggerBase {
 					obj.addError(e.getMessage());
 				}
 			}
-			for (SObject obj : triggerNew) {
-				TriggerBase.idsProcessedBeforeUpdate.add(obj.Id);
-			}
 		} else if (
 			this.context == System.TriggerOperation.AFTER_UPDATE &&
 			this instanceof TriggerAction.AfterUpdate
 		) {
+			for (SObject obj : triggerNew) {
+				if (!idsToNumberOfTimesSeenAfterUpdate.containsKey(obj.id)) {
+					idsToNumberOfTimesSeenAfterUpdate.put(obj.id, 1);
+				} else {
+					idsToNumberOfTimesSeenAfterUpdate.put(
+						obj.id,
+						idsToNumberOfTimesSeenAfterUpdate.get(obj.id) + 1
+					);
+				}
+			}
 			try {
 				((TriggerAction.AfterUpdate) this).afterUpdate(triggerNew, triggerOld);
 			} catch (Exception e) {
 				for (SObject obj : triggerNew) {
 					obj.addError(e.getMessage());
 				}
-			}
-			for (SObject obj : triggerNew) {
-				TriggerBase.idsProcessedAfterUpdate.add(obj.Id);
 			}
 		} else if (
 			this.context == System.TriggerOperation.BEFORE_DELETE &&


### PR DESCRIPTION
Fixes #34 by making the recursion prevention mechanism operate on the number of times a record has been seen in the `beforeUpdate` or `afterUpdate` contexts.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR