### PR TITLE
Deactivate the "Must Choose a Context" Validation rule to enable easi…

### DIFF
--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Must_Choose_A_Context.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Must_Choose_A_Context.validationRule-meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Must_Choose_A_Context</fullName>
-    <active>true</active>
+    <active>false</active>
     <description>Throws an error if the user does not choose at least one context</description>
     <errorConditionFormula>ISBLANK(Before_Insert__c)
 &amp;&amp;


### PR DESCRIPTION
Deactivate the "Must Choose a Context" Validation rule to enable easier deployments.

Currently, Salesforce will not recognize that there is a value in a metadata relationship field when parent and custom metadata rows are initially created. This validation rule will execute and prevent deployments from source to Salesforce whenever a new Trigger Action and sObject Trigger Setting are created in the same deployment. This will be activated again when there is a long term fix available.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
