### PR TITLE
TriggerActionFlowIdentifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,13 @@ public with sharing class OpportunityTriggerRecord extends FlowTriggerRecord {
     super();
   }
 
-  public OpportunityTriggerRecord(Opportunity newRecord, Opportunity oldRecord, Integer newRecordIndex) {
-    super(newRecord, oldRecord, newRecordIndex);
+  public OpportunityTriggerRecord(
+    Opportunity newRecord,
+    Opportunity oldRecord,
+    Integer newRecordIndex,
+    Integer triggerActionFlowIdentifier
+  ) {
+    super(newRecord, oldRecord, newRecordIndex, triggerActionFlowIdentifier);
   }
 
   @AuraEnabled
@@ -135,14 +140,22 @@ public with sharing class OpportunityTriggerRecord extends FlowTriggerRecord {
 
   public override Map<String, Object> getFlowInput(
     List<SObject> newList,
-    List<SObject> oldList
+    List<SObject> oldList,
+    Integer triggerActionFlowIdentifier
   ) {
     List<SObject> collection = newList != null ? newList : oldList;
     List<OpportunityTriggerRecord> triggerRecords = new List<OpportunityTriggerRecord>();
     for (Integer i = 0; i < collection.size(); i++) {
-      Opportunity newOpportunity = newList != null ? (Opportunity) newList.get(i) : null;
-      Opportunity oldOpportunity = oldList != null ? (Opportunity) oldList.get(i) : null;
-      triggerRecords.add(new OpportunityTriggerRecord(newOpportunity, oldOpportunity, i));
+      Opportunity newRecord = newList != null ? (Opportunity) newList.get(i) : null;
+      Opportunity oldRecord = oldList != null ? (Opportunity) oldList.get(i) : null;
+      triggerRecords.add(
+        new OpportunityTriggerRecord(
+          newRecord,
+          oldRecord,
+          i,
+          triggerActionFlowIdentifier
+        )
+      );
     }
     return new Map<String, Object>{
       TriggerActionFlow.TRIGGER_RECORDS_VARIABLE => triggerRecords

--- a/trigger-actions-framework/main/default/classes/FlowTriggerRecord.cls
+++ b/trigger-actions-framework/main/default/classes/FlowTriggerRecord.cls
@@ -16,9 +16,12 @@
 
 @SuppressWarnings('PMD.EmptyStatementBlock')
 public abstract class FlowTriggerRecord {
-	public static Map<Integer, SObject> newRecordIndexToNewRecord = new Map<Integer, SObject>();
-	private static final String NEW_RECORD_INDEX_REQUIRED = 'The index of the newRecord in the newList is required.';
-	private Integer newRecordIndex;
+	public static Map<String, SObject> triggerActionFlowIdAndIndexToNewRecord = new Map<String, SObject>();
+	private static final String INVALID_INPUT = 'The index of new list and the Flow identifier are required.';
+	@TestVisible
+	private static final String PIPE = '|';
+	private Integer newListIndex;
+	private Integer triggerActionFlowId;
 
 	public FlowTriggerRecord() {
 		// no argument constructor necessary to use Type.ForName
@@ -27,16 +30,19 @@ public abstract class FlowTriggerRecord {
 	protected FlowTriggerRecord(
 		SObject newSobject,
 		SObject oldSObject,
-		Integer newRecordIndex
+		Integer newListIndex,
+		Integer triggerActionFlowId
 	) {
-		this.newRecordIndex = newRecordIndex;
+		this.newListIndex = newListIndex;
+		this.triggerActionFlowId = triggerActionFlowId;
 		this.newSobject = newSobject;
 		this.oldSobject = oldSobject;
 	}
 
 	public abstract Map<String, Object> getFlowInput(
 		List<SObject> newList,
-		List<SObject> oldList
+		List<SObject> oldList,
+		Integer triggerActionFlowId
 	);
 
 	protected SObject newSobject {
@@ -44,12 +50,14 @@ public abstract class FlowTriggerRecord {
 			return newSobject;
 		}
 		set {
-			this.newSobject = value;
-			if (this.newRecordIndex == null) {
-				throw new IllegalArgumentException(NEW_RECORD_INDEX_REQUIRED);
+			if (this.newListIndex == null || triggerActionFlowId == null) {
+				throw new IllegalArgumentException(INVALID_INPUT);
 			}
-			FlowTriggerRecord.newRecordIndexToNewRecord.put(
-				this.newRecordIndex,
+			this.newSobject = value;
+			FlowTriggerRecord.triggerActionFlowIdAndIndexToNewRecord.put(
+				this.triggerActionFlowId +
+				PIPE +
+				this.newListIndex,
 				newSobject
 			);
 		}

--- a/trigger-actions-framework/main/default/classes/FlowTriggerRecordTest.cls
+++ b/trigger-actions-framework/main/default/classes/FlowTriggerRecordTest.cls
@@ -21,25 +21,37 @@ private class FlowTriggerRecordTest {
 		Id = TestUtility.getFakeId(Schema.Account.SObjectType)
 	);
 
+	static Integer i = 0;
+
 	@IsTest
 	private static void triggerRecordsShouldBeUpdated() {
-		FlowTriggerRecordTest.AccountTriggerRecord testTriggerRecord = new FlowTriggerRecordTest.AccountTriggerRecord(
+		TriggerActionFlowTest.AccountTriggerRecord testTriggerRecord = new TriggerActionFlowTest.AccountTriggerRecord(
 			myAccount,
 			myAccount,
-			0
+			0,
+			i
 		);
 		System.assertEquals(
 			true,
-			FlowTriggerRecord.newRecordIndexToNewRecord.containsKey(0),
-			'The index of the newRecord should be stored in the newRecordIndexToNewRecord map'
+			FlowTriggerRecord.triggerActionFlowIdAndIndexToNewRecord.containsKey(
+				i +
+				FlowTriggerRecord.PIPE +
+				0
+			),
+			'The index of the newRecord should be stored in the triggerActionFlowIdAndIndexToNewRecord map'
 		);
 
 		testTriggerRecord.newRecord.Id = null;
 
 		System.assertEquals(
 			null,
-			FlowTriggerRecord.newRecordIndexToNewRecord.get(0).Id,
-			'Modifications to the newRecord should persist through the newRecordIndexToNewRecord map'
+			FlowTriggerRecord.triggerActionFlowIdAndIndexToNewRecord.get(
+					i +
+					FlowTriggerRecord.PIPE +
+					0
+				)
+				.Id,
+			'Modifications to the newRecord should persist through the triggerActionFlowIdAndIndexToNewRecord map'
 		);
 	}
 
@@ -47,10 +59,11 @@ private class FlowTriggerRecordTest {
 	private static void triggerRecordsShouldThrowExceptionIfTheNewValueIsSetWithoutAnIndex() {
 		Exception myException;
 		try {
-			FlowTriggerRecordTest.AccountTriggerRecord testTriggerRecord = new FlowTriggerRecordTest.AccountTriggerRecord(
+			TriggerActionFlowTest.AccountTriggerRecord testTriggerRecord = new TriggerActionFlowTest.AccountTriggerRecord(
 				myAccount,
 				myAccount,
-				null
+				null,
+				i
 			);
 		} catch (Exception e) {
 			myException = e;
@@ -63,50 +76,24 @@ private class FlowTriggerRecordTest {
 		);
 	}
 
-	public class AccountTriggerRecord extends FlowTriggerRecord {
-		public AccountTriggerRecord() {
-			super();
+	@IsTest
+	private static void triggerRecordsShouldThrowExceptionIfTheNewValueIsSetWithoutATriggerActionFlowIdentifier() {
+		Exception myException;
+		try {
+			TriggerActionFlowTest.AccountTriggerRecord testTriggerRecord = new TriggerActionFlowTest.AccountTriggerRecord(
+				myAccount,
+				myAccount,
+				0,
+				null
+			);
+		} catch (Exception e) {
+			myException = e;
 		}
 
-		public AccountTriggerRecord(
-			Account newRecord,
-			Account oldRecord,
-			Integer newRecordIndex
-		) {
-			super(newRecord, oldRecord, newRecordIndex);
-		}
-
-		@AuraEnabled
-		public Account newRecord {
-			get {
-				return (Account) this.newSObject;
-			}
-			set {
-				this.newSObject = value;
-			}
-		}
-
-		@AuraEnabled
-		public Account oldRecord {
-			get {
-				return (Account) this.oldSObject;
-			}
-		}
-
-		public override Map<String, Object> getFlowInput(
-			List<SObject> newList,
-			List<SObject> oldList
-		) {
-			List<SObject> collection = newList != null ? newList : oldList;
-			List<AccountTriggerRecord> triggerRecords = new List<AccountTriggerRecord>();
-			for (Integer i = 0; i < collection.size(); i++) {
-				Account newRecord = newList != null ? (Account) newList.get(i) : null;
-				Account oldRecord = oldList != null ? (Account) oldList.get(i) : null;
-				triggerRecords.add(new AccountTriggerRecord(newRecord, oldRecord, i));
-			}
-			return new Map<String, Object>{
-				TriggerActionFlow.TRIGGER_RECORDS_VARIABLE => triggerRecords
-			};
-		}
+		System.assertNotEquals(
+			null,
+			myException,
+			'Setting the value of the new sObject should fail without the identifer of the trigger action flow'
+		);
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -29,13 +29,47 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		APEX_STRING,
 		FLOW_STRING
 	};
+	private static final String PIPE = '|';
 	@TestVisible
 	private static Set<String> bypassedFlows = new Set<String>();
 	private static Map<Schema.SObjectType, List<String>> sObjectToEditableFields = new Map<Schema.SObjectType, List<String>>();
+	private static Set<Integer> usedIdentifiers = new Set<Integer>();
 
 	public String flowName;
 	public Boolean allowRecursion;
 	public String flowTriggerRecordClassName;
+
+	private Integer identifier;
+
+	public static void bypass(String flowName) {
+		TriggerActionFlow.bypassedFlows.add(flowName);
+	}
+
+	public static void clearBypass(String flowName) {
+		TriggerActionFlow.bypassedFlows.remove(flowName);
+	}
+
+	public static Boolean isBypassed(String flowName) {
+		return TriggerActionFlow.bypassedFlows.contains(flowName);
+	}
+
+	public static void clearAllBypasses() {
+		TriggerActionFlow.bypassedFlows.clear();
+	}
+
+	public TriggerActionFlow() {
+		boolean foundNovelIdentifier = false;
+		while (foundNovelIdentifier == false) {
+			Integer random = Crypto.getRandomInteger();
+			if (usedIdentifiers.contains(random)) {
+				continue;
+			} else {
+				identifier = random;
+				usedIdentifiers.add(identifier);
+                foundNovelIdentifier = true;
+			}
+		}
+	}
 
 	public void beforeInsert(List<SObject> newList) {
 		if (!thisFlowIsBypassed()) {
@@ -133,22 +167,6 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		}
 	}
 
-	public static void bypass(String flowName) {
-		TriggerActionFlow.bypassedFlows.add(flowName);
-	}
-
-	public static void clearBypass(String flowName) {
-		TriggerActionFlow.bypassedFlows.remove(flowName);
-	}
-
-	public static Boolean isBypassed(String flowName) {
-		return TriggerActionFlow.bypassedFlows.contains(flowName);
-	}
-
-	public static void clearAllBypasses() {
-		TriggerActionFlow.bypassedFlows.clear();
-	}
-
 	private Boolean thisFlowIsBypassed() {
 		if (String.isBlank(flowName)) {
 			throw new TriggerActionFlowException(INVALID_FLOW_NAME);
@@ -160,9 +178,8 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		List<sObject> newList,
 		List<sObject> oldList
 	) {
-		FlowTriggerRecord.newRecordIndexToNewRecord.clear();
 		Map<String, Object> generatedInput = getFlowTriggerRecord()
-			.getFlowInput(newList, oldList);
+			.getFlowInput(newList, oldList, this.identifier);
 		verifyInput(generatedInput);
 		return generatedInput;
 	}
@@ -199,7 +216,9 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 
 		for (Integer i = 0; i < newList.size(); i++) {
 			SObject recordInNewList = newList[i];
-			SObject recordAfterFlowIsComplete = FlowTriggerRecord.newRecordIndexToNewRecord.get(
+			SObject recordAfterFlowIsComplete = FlowTriggerRecord.triggerActionFlowIdAndIndexToNewRecord.get(
+				this.identifier +
+				PIPE +
 				i
 			);
 			for (String fieldName : editableFields) {
@@ -214,7 +233,6 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 				}
 			}
 		}
-		FlowTriggerRecord.newRecordIndexToNewRecord = new Map<Integer, SObject>();
 	}
 
 	private List<String> getEditableFields(

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -15,7 +15,7 @@
  */
 
 @IsTest(isParallel=true)
-private class TriggerActionFlowTest {
+public class TriggerActionFlowTest {
 	private static final String MY_ACCOUNT = 'My Account';
 	private static final String OLD_NAME = 'Old Name';
 	private static final String BOGUS = 'Bogus';
@@ -268,9 +268,10 @@ private class TriggerActionFlowTest {
 		public AccountTriggerRecord(
 			Account newRecord,
 			Account oldRecord,
-			Integer newRecordIndex
+			Integer newRecordIndex,
+			Integer triggerActionFlowIdentifier
 		) {
-			super(newRecord, oldRecord, newRecordIndex);
+			super(newRecord, oldRecord, newRecordIndex, triggerActionFlowIdentifier);
 		}
 
 		@AuraEnabled
@@ -292,14 +293,22 @@ private class TriggerActionFlowTest {
 
 		public override Map<String, Object> getFlowInput(
 			List<SObject> newList,
-			List<SObject> oldList
+			List<SObject> oldList,
+			Integer triggerActionFlowIdentifier
 		) {
 			List<SObject> collection = newList != null ? newList : oldList;
 			List<AccountTriggerRecord> triggerRecords = new List<AccountTriggerRecord>();
 			for (Integer i = 0; i < collection.size(); i++) {
 				Account newRecord = newList != null ? (Account) newList.get(i) : null;
 				Account oldRecord = oldList != null ? (Account) oldList.get(i) : null;
-				triggerRecords.add(new AccountTriggerRecord(newRecord, oldRecord, i));
+				triggerRecords.add(
+					new AccountTriggerRecord(
+						newRecord,
+						oldRecord,
+						i,
+						triggerActionFlowIdentifier
+					)
+				);
 			}
 			return new Map<String, Object>{
 				TriggerActionFlow.TRIGGER_RECORDS_VARIABLE => triggerRecords
@@ -310,7 +319,8 @@ private class TriggerActionFlowTest {
 	private class BadInputWrongVariable extends FlowTriggerRecord {
 		public override Map<String, Object> getFlowInput(
 			List<SObject> newList,
-			List<SObject> oldList
+			List<SObject> oldList,
+			Integer triggerActionFlowIdentifier
 		) {
 			return new Map<String, Object>{
 				BOGUS => new List<AccountTriggerRecord>()
@@ -321,7 +331,8 @@ private class TriggerActionFlowTest {
 	private class BadInputWrongReturnType extends FlowTriggerRecord {
 		public override Map<String, Object> getFlowInput(
 			List<SObject> newList,
-			List<SObject> oldList
+			List<SObject> oldList,
+			Integer triggerActionFlowIdentifier
 		) {
 			return new Map<String, Object>{
 				TriggerActionFlow.TRIGGER_RECORDS_VARIABLE => BOGUS


### PR DESCRIPTION
- Add a new TriggerActionFlowIdentifier to enable cascading before insert and before update flows.
- Use `triggerActionFlowIdentifier|newListIndex` as a key to decrease risk of race conditions and collision on simple index match

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
