### PR TITLE
Flow action cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png" alt="Deploy to Salesforce" />
 </a>
 
-#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaIdAAK)
+#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaInAAK)
 
-#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaIdAAK)
+#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaInAAK)
 
 ---
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -14,6 +14,7 @@
   "packageAliases": {
     "Trigger Actions Framework": "0Ho3h0000008Om4CAE",
     "Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",
-    "Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK"
+    "Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK",
+    "Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK"
   }
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
@@ -1,0 +1,14 @@
+public class TriggerActionConstants {
+	public static final String APEX_STRING = 'Apex';
+	public static final String FLOW_STRING = 'Flow';
+	public static final String OBJECT_STRING = 'Object';
+	public static final String RECORD_PRIOR_VARIABLE = 'recordPrior';
+	public static final String RECORD_VARIABLE = 'record';
+	public static final String INVALID_FLOW_NAME = 'You must provide the name of a flow to execute';
+	public static final String INVALID_TYPE = 'The bypassType must equal Object, Apex, or Flow';
+	public static final Set<String> REQUEST_TYPES = new Set<String>{
+		TriggerActionConstants.APEX_STRING,
+		TriggerActionConstants.FLOW_STRING,
+		TriggerActionConstants.OBJECT_STRING
+	};
+}

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
@@ -1,3 +1,18 @@
+/*
+   Copyright 2020 Google LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
 public class TriggerActionConstants {
 	public static final String APEX_STRING = 'Apex';
 	public static final String FLOW_STRING = 'Flow';

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -15,19 +15,6 @@
  */
 
 public inherited sharing class TriggerActionFlow implements TriggerAction.BeforeInsert, TriggerAction.AfterInsert, TriggerAction.BeforeUpdate, TriggerAction.AfterUpdate, TriggerAction.BeforeDelete, TriggerAction.AfterDelete, TriggerAction.AfterUndelete {
-	public static final String APEX_STRING = 'Apex';
-	public static final String FLOW_STRING = 'Flow';
-	public static final String OBJECT_STRING = 'Object';
-	@TestVisible
-	private static final String INVALID_TYPE = 'The bypassType must equal Object, Apex, or Flow';
-	private static final String INVALID_FLOW_NAME = 'You must provide the name of a flow to execute';
-	private static final String RECORD_PRIOR_VARIABLE = 'recordPrior';
-	private static final String RECORD_VARIABLE = 'record';
-	private static final Set<String> REQUEST_TYPES = new Set<String>{
-		OBJECT_STRING,
-		APEX_STRING,
-		FLOW_STRING
-	};
 	@TestVisible
 	private static Set<String> bypassedFlows = new Set<String>();
 	private static Map<Schema.SObjectType, List<String>> sObjectToEditableFields = new Map<Schema.SObjectType, List<String>>();
@@ -52,8 +39,8 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public static void validateType(String bypassType) {
-		if (!TriggerActionFlow.REQUEST_TYPES.contains(bypassType)) {
-			throw new IllegalArgumentException(TriggerActionFlow.INVALID_TYPE);
+		if (!TriggerActionConstants.REQUEST_TYPES.contains(bypassType)) {
+			throw new IllegalArgumentException(TriggerActionConstants.INVALID_TYPE);
 		}
 	}
 
@@ -62,7 +49,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			return;
 		}
 		List<Invocable.Action.Result> results = invokeAction(
-			getInterviewInputs(newList, RECORD_VARIABLE)
+			getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
 		);
 		handleInvocableResults(results, newList);
 		applyFieldValuesDuringBefore(results, newList);
@@ -73,7 +60,9 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			return;
 		}
 		handleInvocableResults(
-			invokeAction(getInterviewInputs(newList, RECORD_VARIABLE)),
+			invokeAction(
+				getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
+			),
 			newList
 		);
 	}
@@ -130,7 +119,12 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			return;
 		}
 		handleInvocableResults(
-			invokeAction(getInterviewInputs(oldList, RECORD_PRIOR_VARIABLE)),
+			invokeAction(
+				getInterviewInputs(
+					oldList,
+					TriggerActionConstants.RECORD_PRIOR_VARIABLE
+				)
+			),
 			oldList
 		);
 	}
@@ -140,7 +134,12 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			return;
 		}
 		handleInvocableResults(
-			invokeAction(getInterviewInputs(oldList, RECORD_PRIOR_VARIABLE)),
+			invokeAction(
+				getInterviewInputs(
+					oldList,
+					TriggerActionConstants.RECORD_PRIOR_VARIABLE
+				)
+			),
 			oldList
 		);
 	}
@@ -150,14 +149,18 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			return;
 		}
 		handleInvocableResults(
-			invokeAction(getInterviewInputs(newList, RECORD_VARIABLE)),
+			invokeAction(
+				getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
+			),
 			newList
 		);
 	}
 
 	private Boolean thisFlowIsBypassed() {
 		if (String.isBlank(flowName)) {
-			throw new IllegalArgumentException(INVALID_FLOW_NAME);
+			throw new IllegalArgumentException(
+				TriggerActionConstants.INVALID_FLOW_NAME
+			);
 		}
 		return TriggerActionFlow.isBypassed(flowName);
 	}
@@ -166,7 +169,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		List<Map<String, Object>> inputs
 	) {
 		Invocable.Action action = Invocable.Action.createCustomAction(
-			FLOW_STRING,
+			TriggerActionConstants.FLOW_STRING,
 			this.flowName
 		);
 		action.setInvocations(inputs);
@@ -199,8 +202,8 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			SObject newRecord = newList[i];
 			result.add(
 				new Map<String, Object>{
-					RECORD_PRIOR_VARIABLE => oldRecord,
-					RECORD_VARIABLE => newRecord
+					TriggerActionConstants.RECORD_PRIOR_VARIABLE => oldRecord,
+					TriggerActionConstants.RECORD_VARIABLE => newRecord
 				}
 			);
 		}
@@ -254,7 +257,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 			Invocable.Action.Result result = results[i];
 			if (result.isSuccess() == true) {
 				SObject newRecordWhenFlowIsComplete = (SObject) (result.getOutputParameters()
-					.get(RECORD_VARIABLE));
+					.get(TriggerActionConstants.RECORD_VARIABLE));
 				applyFlowValues(
 					newList[i],
 					newRecordWhenFlowIsComplete,

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
@@ -23,7 +23,7 @@ public inherited sharing class TriggerActionFlowBypass {
 	public static void bypass(List<Request> requests) {
 		TriggerActionFlowBypassProcessor bypassProcessor = new FlowBypassProcessor();
 		for (Request myRequest : requests) {
-			bypassProcessor.hasActionBeenPerformed(
+			bypassProcessor.execute(
 				myRequest.bypassType,
 				myRequest.name
 			);

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
@@ -21,15 +21,12 @@ public inherited sharing class TriggerActionFlowBypass {
 		description='Sets the static bypass to true for this object, apex action, or flow action.'
 	)
 	public static void bypass(List<Request> requests) {
-		for (Request current : requests) {
-			TriggerActionFlow.validateType(current.bypassType);
-			if (current.bypassType == TriggerActionFlow.OBJECT_STRING) {
-				TriggerBase.bypass(current.name);
-			} else if (current.bypassType == TriggerActionFlow.APEX_STRING) {
-				MetadataTriggerHandler.bypass(current.name);
-			} else if (current.bypassType == TriggerActionFlow.FLOW_STRING) {
-				TriggerActionFlow.bypass(current.name);
-			}
+		TriggerActionFlowBypassProcessor bypassProcessor = new FlowBypassProcessor();
+		for (Request myRequest : requests) {
+			bypassProcessor.hasActionBeenPerformed(
+				myRequest.bypassType,
+				myRequest.name
+			);
 		}
 	}
 
@@ -46,5 +43,19 @@ public inherited sharing class TriggerActionFlowBypass {
 			required=true
 		)
 		public String bypassType;
+	}
+
+	private class FlowBypassProcessor extends TriggerActionFlowBypassProcessor {
+		protected override void processApexBypasses(String name) {
+			MetadataTriggerHandler.bypass(name);
+		}
+
+		protected override void processFlowBypasses(String name) {
+			TriggerActionFlow.bypass(name);
+		}
+
+		protected override void processObjectBypasses(String name) {
+			TriggerBase.bypass(name);
+		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
@@ -14,15 +14,8 @@
    limitations under the License.
  */
 public inherited sharing abstract class TriggerActionFlowBypassProcessor {
-	public static final Set<String> REQUEST_TYPES = new Set<String>{
-		TriggerActionConstants.APEX_STRING,
-		TriggerActionConstants.FLOW_STRING,
-		TriggerActionConstants.OBJECT_STRING
-	};
 
-	protected Boolean hasActionBeenPerformed = true;
-
-	public Boolean hasActionBeenPerformed(
+	public void execute(
 		String requestType,
 		String requestName
 	) {
@@ -35,7 +28,6 @@ public inherited sharing abstract class TriggerActionFlowBypassProcessor {
 		} else if (requestType == TriggerActionConstants.OBJECT_STRING) {
 			this.processObjectBypasses(requestName);
 		}
-		return this.hasActionBeenPerformed;
 	}
 
 	protected abstract void processApexBypasses(String requestType);

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
@@ -1,0 +1,44 @@
+/*
+   Copyright 2022 Google LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+public inherited sharing abstract class TriggerActionFlowBypassProcessor {
+	public static final Set<String> REQUEST_TYPES = new Set<String>{
+		TriggerActionConstants.APEX_STRING,
+		TriggerActionConstants.FLOW_STRING,
+		TriggerActionConstants.OBJECT_STRING
+	};
+
+	protected Boolean hasActionBeenPerformed = true;
+
+	public Boolean hasActionBeenPerformed(
+		String requestType,
+		String requestName
+	) {
+		if (!TriggerActionConstants.REQUEST_TYPES.contains(requestType)) {
+			throw new IllegalArgumentException(TriggerActionConstants.INVALID_TYPE);
+		} else if (requestType == TriggerActionConstants.FLOW_STRING) {
+			this.processFlowBypasses(requestName);
+		} else if (requestType == TriggerActionConstants.APEX_STRING) {
+			this.processApexBypasses(requestName);
+		} else if (requestType == TriggerActionConstants.OBJECT_STRING) {
+			this.processObjectBypasses(requestName);
+		}
+		return this.hasActionBeenPerformed;
+	}
+
+	protected abstract void processApexBypasses(String requestType);
+	protected abstract void processFlowBypasses(String requestType);
+	protected abstract void processObjectBypasses(String requestType);
+}

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
@@ -24,7 +24,7 @@ private class TriggerActionFlowBypassTest {
 	@IsTest
 	private static void bypassObjectShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.OBJECT_STRING;
+		request.bypassType = TriggerActionConstants.OBJECT_STRING;
 		requests.add(request);
 
 		TriggerActionFlowBypass.bypass(requests);
@@ -39,7 +39,7 @@ private class TriggerActionFlowBypassTest {
 	@IsTest
 	private static void bypassApexShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.APEX_STRING;
+		request.bypassType = TriggerActionConstants.APEX_STRING;
 		requests.add(request);
 
 		TriggerActionFlowBypass.bypass(requests);
@@ -54,7 +54,7 @@ private class TriggerActionFlowBypassTest {
 	@IsTest
 	private static void bypassFlowShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.FLOW_STRING;
+		request.bypassType = TriggerActionConstants.FLOW_STRING;
 		requests.add(request);
 
 		TriggerActionFlowBypass.bypass(requests);
@@ -83,13 +83,14 @@ private class TriggerActionFlowBypassTest {
 			myException,
 			'We should have an exception thrown in this scenario'
 		);
-		System.assert(
-			myException instanceof IllegalArgumentException,
+		Assert.isInstanceOfType(
+			myException,
+			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
 		System.assertEquals(
 			myException.getMessage(),
-			TriggerActionFlow.INVALID_TYPE,
+			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'
 		);
 	}

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
@@ -23,7 +23,7 @@ public inherited sharing class TriggerActionFlowClearAllBypasses {
 	public static void clearAllBypasses(List<String> requests) {
 		TriggerActionFlowBypassProcessor bypassProcessor = new ClearBypassesProcessor();
 		for (String myRequest : requests) {
-			bypassProcessor.hasActionBeenPerformed(myRequest, myRequest);
+			bypassProcessor.execute(myRequest, myRequest);
 		}
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
@@ -21,15 +21,23 @@ public inherited sharing class TriggerActionFlowClearAllBypasses {
 		description='Sets the static bypass to false for all objects, apex actions, or flow actions.'
 	)
 	public static void clearAllBypasses(List<String> requests) {
-		for (String current : requests) {
-			TriggerActionFlow.validateType(current);
-			if (current == TriggerActionFlow.OBJECT_STRING) {
-				TriggerBase.clearAllBypasses();
-			} else if (current == TriggerActionFlow.APEX_STRING) {
-				MetadataTriggerHandler.clearAllBypasses();
-			} else if (current == TriggerActionFlow.FLOW_STRING) {
-				TriggerActionFlow.clearAllBypasses();
-			}
+		TriggerActionFlowBypassProcessor bypassProcessor = new ClearBypassesProcessor();
+		for (String myRequest : requests) {
+			bypassProcessor.hasActionBeenPerformed(myRequest, myRequest);
+		}
+	}
+
+	private class ClearBypassesProcessor extends TriggerActionFlowBypassProcessor {
+		protected override void processApexBypasses(String name) {
+			MetadataTriggerHandler.clearAllBypasses();
+		}
+
+		protected override void processFlowBypasses(String name) {
+			TriggerActionFlow.clearAllBypasses();
+		}
+
+		protected override void processObjectBypasses(String name) {
+			TriggerBase.clearAllBypasses();
 		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
@@ -23,7 +23,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 		TriggerBase.bypass(MY_STRING);
 
 		TriggerActionFlowClearAllBypasses.clearAllBypasses(
-			new List<String>{ TriggerActionFlow.OBJECT_STRING }
+			new List<String>{ TriggerActionConstants.OBJECT_STRING }
 		);
 
 		System.assertEquals(
@@ -38,7 +38,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 		MetadataTriggerHandler.bypass(MY_STRING);
 
 		TriggerActionFlowClearAllBypasses.clearAllBypasses(
-			new List<String>{ TriggerActionFlow.APEX_STRING }
+			new List<String>{ TriggerActionConstants.APEX_STRING }
 		);
 
 		System.assertEquals(
@@ -53,7 +53,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 		TriggerActionFlow.bypass(MY_STRING);
 
 		TriggerActionFlowClearAllBypasses.clearAllBypasses(
-			new List<String>{ TriggerActionFlow.FLOW_STRING }
+			new List<String>{ TriggerActionConstants.FLOW_STRING }
 		);
 
 		System.assertEquals(
@@ -80,13 +80,14 @@ private class TriggerActionFlowClearAllBypassesTest {
 			myException,
 			'We should have an exception thrown in this scenario'
 		);
-		System.assert(
-			myException instanceof IllegalArgumentException,
+		Assert.isInstanceOfType(
+			myException,
+			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
 		System.assertEquals(
 			myException.getMessage(),
-			TriggerActionFlow.INVALID_TYPE,
+			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'
 		);
 	}

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
@@ -23,7 +23,7 @@ public inherited sharing class TriggerActionFlowClearBypass {
 	public static void clearBypass(List<Request> requests) {
 		TriggerActionFlowBypassProcessor bypassProcesser = new FlowClearBypassProcessor();
 		for (Request myRequest : requests) {
-			bypassProcesser.hasActionBeenPerformed(
+			bypassProcesser.execute(
 				myRequest.bypassType,
 				myRequest.name
 			);

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
@@ -21,15 +21,12 @@ public inherited sharing class TriggerActionFlowClearBypass {
 		description='Sets the static bypass to false for this object, apex action, or flow action.'
 	)
 	public static void clearBypass(List<Request> requests) {
-		for (Request current : requests) {
-			TriggerActionFlow.validateType(current.bypassType);
-			if (current.bypassType == TriggerActionFlow.OBJECT_STRING) {
-				TriggerBase.clearBypass(current.name);
-			} else if (current.bypassType == TriggerActionFlow.APEX_STRING) {
-				MetadataTriggerHandler.clearBypass(current.name);
-			} else if (current.bypassType == TriggerActionFlow.FLOW_STRING) {
-				TriggerActionFlow.clearBypass(current.name);
-			}
+		TriggerActionFlowBypassProcessor bypassProcesser = new FlowClearBypassProcessor();
+		for (Request myRequest : requests) {
+			bypassProcesser.hasActionBeenPerformed(
+				myRequest.bypassType,
+				myRequest.name
+			);
 		}
 	}
 
@@ -46,5 +43,19 @@ public inherited sharing class TriggerActionFlowClearBypass {
 			required=true
 		)
 		public String bypassType;
+	}
+
+	private class FlowClearBypassProcessor extends TriggerActionFlowBypassProcessor {
+		protected override void processApexBypasses(String name) {
+			MetadataTriggerHandler.clearBypass(name);
+		}
+
+		protected override void processFlowBypasses(String name) {
+			TriggerActionFlow.clearBypass(name);
+		}
+
+		protected override void processObjectBypasses(String name) {
+			TriggerBase.clearBypass(name);
+		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
@@ -25,7 +25,7 @@ private class TriggerActionFlowClearBypassTest {
 	private static void clearBypassObjecthouldSucceedWithValidRequest() {
 		TriggerBase.bypass(MY_STRING);
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.OBJECT_STRING;
+		request.bypassType = TriggerActionConstants.OBJECT_STRING;
 		requests.add(request);
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
@@ -41,7 +41,7 @@ private class TriggerActionFlowClearBypassTest {
 	private static void clearBypassApexShouldSucceedWithValidRequest() {
 		MetadataTriggerHandler.bypass(MY_STRING);
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.APEX_STRING;
+		request.bypassType = TriggerActionConstants.APEX_STRING;
 		requests.add(request);
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
@@ -57,7 +57,7 @@ private class TriggerActionFlowClearBypassTest {
 	private static void clearBypassFlowShouldSucceedWithValidRequest() {
 		TriggerActionFlow.bypass(MY_STRING);
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.FLOW_STRING;
+		request.bypassType = TriggerActionConstants.FLOW_STRING;
 		requests.add(request);
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
@@ -86,13 +86,14 @@ private class TriggerActionFlowClearBypassTest {
 			myException,
 			'We should have an exception thrown in this scenario'
 		);
-		System.assert(
-			myException instanceof IllegalArgumentException,
+		Assert.isInstanceOfType(
+			myException,
+			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
 		System.assertEquals(
 			myException.getMessage(),
-			TriggerActionFlow.INVALID_TYPE,
+			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'
 		);
 	}

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
@@ -22,13 +22,13 @@ public inherited sharing class TriggerActionFlowIsBypassed {
 	)
 	public static List<Boolean> isBypassed(List<Request> requests) {
 		List<Boolean> results = new List<Boolean>();
-		TriggerActionFlowBypassProcessor bypassProcesser = new FlowIsBypassedProcesser();
+		FlowIsBypassedProcesser bypassProcesser = new FlowIsBypassedProcesser();
 		for (Request myRequest : requests) {
-			Boolean result = bypassProcesser.hasActionBeenPerformed(
+			bypassProcesser.execute(
 				myRequest.bypassType,
 				myRequest.name
 			);
-			results.add(result);
+			results.add(bypassProcesser.getHasBeenBypassed());
 		}
 		return results;
 	}
@@ -41,16 +41,22 @@ public inherited sharing class TriggerActionFlowIsBypassed {
 	}
 
 	private class FlowIsBypassedProcesser extends TriggerActionFlowBypassProcessor {
+		private Boolean hasBeenBypassed = false;
+
+		public Boolean getHasBeenBypassed() {
+			return this.hasBeenBypassed;
+		}
+
 		protected override void processApexBypasses(String name) {
-			this.hasActionBeenPerformed = MetadataTriggerHandler.isBypassed(name);
+			this.hasBeenBypassed = MetadataTriggerHandler.isBypassed(name);
 		}
 
 		protected override void processFlowBypasses(String name) {
-			this.hasActionBeenPerformed = TriggerActionFlow.isBypassed(name);
+			this.hasBeenBypassed = TriggerActionFlow.isBypassed(name);
 		}
 
 		protected override void processObjectBypasses(String name) {
-			this.hasActionBeenPerformed = TriggerBase.isBypassed(name);
+			this.hasBeenBypassed = TriggerBase.isBypassed(name);
 		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
@@ -22,16 +22,12 @@ public inherited sharing class TriggerActionFlowIsBypassed {
 	)
 	public static List<Boolean> isBypassed(List<Request> requests) {
 		List<Boolean> results = new List<Boolean>();
-		for (Request current : requests) {
-			TriggerActionFlow.validateType(current.bypassType);
-			Boolean result = false;
-			if (current.bypassType == TriggerActionFlow.OBJECT_STRING) {
-				result = TriggerBase.isBypassed(current.name);
-			} else if (current.bypassType == TriggerActionFlow.APEX_STRING) {
-				result = MetadataTriggerHandler.isBypassed(current.name);
-			} else if (current.bypassType == TriggerActionFlow.FLOW_STRING) {
-				result = TriggerActionFlow.isBypassed(current.name);
-			}
+		TriggerActionFlowBypassProcessor bypassProcesser = new FlowIsBypassedProcesser();
+		for (Request myRequest : requests) {
+			Boolean result = bypassProcesser.hasActionBeenPerformed(
+				myRequest.bypassType,
+				myRequest.name
+			);
 			results.add(result);
 		}
 		return results;
@@ -42,5 +38,19 @@ public inherited sharing class TriggerActionFlowIsBypassed {
 		public String name;
 		@InvocableVariable
 		public String bypassType;
+	}
+
+	private class FlowIsBypassedProcesser extends TriggerActionFlowBypassProcessor {
+		protected override void processApexBypasses(String name) {
+			this.hasActionBeenPerformed = MetadataTriggerHandler.isBypassed(name);
+		}
+
+		protected override void processFlowBypasses(String name) {
+			this.hasActionBeenPerformed = TriggerActionFlow.isBypassed(name);
+		}
+
+		protected override void processObjectBypasses(String name) {
+			this.hasActionBeenPerformed = TriggerBase.isBypassed(name);
+		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
@@ -24,7 +24,7 @@ private class TriggerActionFlowIsBypassedTest {
 	@IsTest
 	private static void isBypassedObjectShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.OBJECT_STRING;
+		request.bypassType = TriggerActionConstants.OBJECT_STRING;
 		requests.add(request);
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
@@ -44,7 +44,7 @@ private class TriggerActionFlowIsBypassedTest {
 	@IsTest
 	private static void isBypassedApexShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.APEX_STRING;
+		request.bypassType = TriggerActionConstants.APEX_STRING;
 		requests.add(request);
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
@@ -64,7 +64,7 @@ private class TriggerActionFlowIsBypassedTest {
 	@IsTest
 	private static void isBypassedFlowShouldSucceedWithValidRequest() {
 		request.Name = MY_STRING;
-		request.bypassType = TriggerActionFlow.FLOW_STRING;
+		request.bypassType = TriggerActionConstants.FLOW_STRING;
 		requests.add(request);
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
@@ -100,13 +100,14 @@ private class TriggerActionFlowIsBypassedTest {
 			myException,
 			'We should have an exception thrown in this scenario'
 		);
-		System.assert(
-			myException instanceof IllegalArgumentException,
+		Assert.isInstanceOfType(
+			myException,
+			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
 		System.assertEquals(
 			myException.getMessage(),
-			TriggerActionFlow.INVALID_TYPE,
+			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'
 		);
 	}


### PR DESCRIPTION
* Fixes duplication introduced in #84 by standardizing processing logic for different kinds of Flow bypass requests
* Updates `TestUtility` class name to `TriggerActionTestUtility`
* Standardizes title case usage of `@IsTest` annotation

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

@mitchspano there were a few `INVALID_REQUEST` properties that I didn't clean up, though they have no actual usages. I speculated that perhaps you were keeping some static members around so as to have better debugging output, but if they're truly unused I'd be happy to remove them in this PR as well.

Edit - I also didn't bump the API version to 56, but I noticed that could be done as well.