### PR TITLE
Remove `IsUpdatable()` check to provide parity with Record Triggered Flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png" alt="Deploy to Salesforce" />
 </a>
 
-#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaInAAK)
+#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaJWAA0)
 
-#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaInAAK)
+#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaJWAA0)
 
 ---
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,20 +1,21 @@
 {
-  "packageDirectories": [
-    {
-      "path": "trigger-actions-framework",
-      "default": true,
-      "package": "Trigger Actions Framework",
-      "versionName": "ver 0.1",
-      "versionNumber": "0.1.0.NEXT"
+    "packageDirectories": [
+        {
+            "path": "trigger-actions-framework",
+            "default": true,
+            "package": "Trigger Actions Framework",
+            "versionName": "ver 0.1",
+            "versionNumber": "0.1.0.NEXT"
+        }
+    ],
+    "namespace": "",
+    "sfdcLoginUrl": "https://login.salesforce.com",
+    "sourceApiVersion": "55.0",
+    "packageAliases": {
+        "Trigger Actions Framework": "0Ho3h0000008Om4CAE",
+        "Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",
+        "Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK",
+        "Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK",
+        "Trigger Actions Framework@0.1.4-0": "04t3h000004VaJWAA0"
     }
-  ],
-  "namespace": "",
-  "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "55.0",
-  "packageAliases": {
-    "Trigger Actions Framework": "0Ho3h0000008Om4CAE",
-    "Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",
-    "Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK",
-    "Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK"
-  }
 }

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -178,15 +178,11 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 
 	private void applyFlowValues(
 		sObject stateBeforeFlow,
-		sObject stateAfterFlow,
-		List<String> editableFields
+		sObject stateAfterFlow
 	) {
 		Map<String, Object> afterFlowMap = stateAfterFlow.getPopulatedFieldsAsMap();
-		for (String fieldName : editableFields) {
-			if (
-				afterFlowMap.containsKey(fieldName) &&
-				stateBeforeFlow.get(fieldName) != stateAfterFlow.get(fieldName)
-			) {
+		for (String fieldName : afterFlowMap.keySet()) {
+			if (stateBeforeFlow.get(fieldName) != stateAfterFlow.get(fieldName)) {
 				stateBeforeFlow.put(fieldName, stateAfterFlow.get(fieldName));
 			}
 		}
@@ -221,28 +217,6 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		return result;
 	}
 
-	private List<String> getEditableFields(
-		Schema.SObjectType newRecordSObjectType
-	) {
-		if (sObjectToEditableFields.containsKey(newRecordSObjectType)) {
-			return sObjectToEditableFields.get(newRecordSObjectType);
-		}
-		List<String> editableFields = new List<String>();
-		for (
-			Schema.SObjectField fieldRef : newRecordSObjectType
-				.getDescribe()
-				.fields.getMap()
-				.values()
-		) {
-			Schema.DescribeFieldResult fieldResult = fieldRef.getDescribe();
-			if (fieldResult.isUpdateable()) {
-				editableFields.add(fieldResult.getName());
-			}
-		}
-		sObjectToEditableFields.put(newRecordSObjectType, editableFields);
-		return sObjectToEditableFields.get(newRecordSObjectType);
-	}
-
 	private void applyFieldValuesDuringBefore(
 		List<Invocable.Action.Result> results,
 		List<SObject> newList
@@ -250,19 +224,12 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		if (newList.isEmpty()) {
 			return;
 		}
-		List<String> editableFields = getEditableFields(
-			newList[0].getSObjectType()
-		);
 		for (Integer i = 0; i < results.size(); i++) {
 			Invocable.Action.Result result = results[i];
 			if (result.isSuccess() == true) {
 				SObject newRecordWhenFlowIsComplete = (SObject) (result.getOutputParameters()
 					.get(TriggerActionConstants.RECORD_VARIABLE));
-				applyFlowValues(
-					newList[i],
-					newRecordWhenFlowIsComplete,
-					editableFields
-				);
+				applyFlowValues(newList[i], newRecordWhenFlowIsComplete);
 			}
 		}
 	}


### PR DESCRIPTION
No longer rely upon`IsUpdatable()` because that can return false when FLS is not granted for the current user.

This changes that behavior and provides parity with how record triggered flows operate.

Fixes #88

*NOTE:* The user could still try to update a field which they are not supposed to in a flow. This will now produce a runtime error. Here's and example of a flow which tries to set the CaseNumber to `123`

<img width="834" alt="image" src="https://user-images.githubusercontent.com/18402464/204725617-50acc993-c6df-4a3f-a2b4-c68fe84afd23.png">

When this flow is executed, the user will receive an exception:
<img width="476" alt="image" src="https://user-images.githubusercontent.com/18402464/204725700-dcf245b4-2225-4778-9f32-0d436d9e532a.png">


- [x] Tests pass
- [x] Appropriate changes to README are included in PR
