### PR TITLE
Update api to 56.0 and convert tests to use new System.Assert class

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -10,7 +10,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "55.0",
+    "sourceApiVersion": "56.0",
     "packageAliases": {
         "Trigger Actions Framework": "0Ho3h0000008Om4CAE",
         "Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
@@ -64,7 +64,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.beforeInsert(handler.triggerNew);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -86,8 +86,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -120,8 +120,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -149,7 +149,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.afterInsert(handler.triggerNew);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -169,8 +169,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -201,8 +201,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -232,7 +232,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.beforeUpdate(handler.triggerNew, handler.triggerOld);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -254,8 +254,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -288,8 +288,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -317,7 +317,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.afterUpdate(handler.triggerNew, handler.triggerOld);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -337,8 +337,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -369,8 +369,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -400,7 +400,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.beforeDelete(handler.triggerOld);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -422,8 +422,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -456,8 +456,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -485,7 +485,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.afterDelete(handler.triggerOld);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -505,8 +505,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -537,8 +537,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -568,7 +568,7 @@ private class MetadataTriggerHandlerTest {
 
 		handler.afterUndelete(handler.triggerOld);
 
-		System.assertEquals(true, executed, 'We expect the action to be executed');
+		System.Assert.isTrue(executed, 'We expect the action to be executed');
 	}
 
 	@IsTest
@@ -590,8 +590,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_TYPE_ERROR,
@@ -624,8 +624,8 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assertEquals(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
 				MetadataTriggerHandler.INVALID_CLASS_ERROR,
@@ -641,37 +641,37 @@ private class MetadataTriggerHandlerTest {
 
 	@IsTest
 	private static void actionMetadataShouldConstruct() {
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.beforeInsertActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.afterInsertActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.beforeUpdateActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.afterUpdateActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.beforeDeleteActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.afterDeleteActionMetadata,
 			'The metadata should be populated properly'
 		);
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			handler.afterUndeleteActionMetadata,
 			'The metadata should be populated properly'
@@ -682,7 +682,7 @@ private class MetadataTriggerHandlerTest {
 	private static void bypassShouldSucceed() {
 		MetadataTriggerHandler.bypass(TEST_BEFORE_INSERT);
 
-		System.assert(
+		System.Assert.isTrue(
 			MetadataTriggerHandler.bypassedActions.contains(TEST_BEFORE_INSERT),
 			'All bypasses should be configured correctly'
 		);
@@ -693,8 +693,8 @@ private class MetadataTriggerHandlerTest {
 		MetadataTriggerHandler.bypass(TEST_BEFORE_INSERT);
 		MetadataTriggerHandler.clearBypass(TEST_BEFORE_INSERT);
 
-		System.assert(
-			!MetadataTriggerHandler.bypassedActions.contains(TEST_BEFORE_INSERT),
+		System.Assert.isFalse(
+			MetadataTriggerHandler.bypassedActions.contains(TEST_BEFORE_INSERT),
 			'All bypasses should be configured correctly'
 		);
 	}
@@ -706,8 +706,7 @@ private class MetadataTriggerHandlerTest {
 
 		isBypassed = MetadataTriggerHandler.isBypassed(TEST_BEFORE_INSERT);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			isBypassed,
 			'All bypasses should be configured correctly'
 		);
@@ -719,7 +718,7 @@ private class MetadataTriggerHandlerTest {
 
 		MetadataTriggerHandler.clearAllBypasses();
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			0,
 			MetadataTriggerHandler.bypassedActions.size(),
 			'All bypasses should be configured correctly'

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
@@ -30,17 +30,16 @@ private class TriggerActionFlowAddErrorTest {
 
 		TriggerActionFlowAddError.addError(requests);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			account.hasErrors(),
 			'The Account should have an error'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			1,
 			account.getErrors().size(),
 			'There should only be one error'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			MY_STRING,
 			account.getErrors()[0].getMessage(),
 			'The error should contain the message we are looking for'
@@ -57,17 +56,16 @@ private class TriggerActionFlowAddErrorTest {
 
 		TriggerActionFlowAddError.addError(requests);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			account.hasErrors(),
 			'The Account should have an error'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			1,
 			account.getErrors().size(),
 			'There should only be one error'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			MY_STRING,
 			account.getErrors()[0].getMessage(),
 			'The error should contain the message we are looking for'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
@@ -29,8 +29,7 @@ private class TriggerActionFlowBypassTest {
 
 		TriggerActionFlowBypass.bypass(requests);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			TriggerBase.isBypassed(MY_STRING),
 			'The Object should be bypassed'
 		);
@@ -44,8 +43,7 @@ private class TriggerActionFlowBypassTest {
 
 		TriggerActionFlowBypass.bypass(requests);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			MetadataTriggerHandler.isBypassed(MY_STRING),
 			'The Apex should be bypassed'
 		);
@@ -59,8 +57,7 @@ private class TriggerActionFlowBypassTest {
 
 		TriggerActionFlowBypass.bypass(requests);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			TriggerActionFlow.isBypassed(MY_STRING),
 			'The Flow should be bypassed'
 		);
@@ -78,7 +75,7 @@ private class TriggerActionFlowBypassTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			myException,
 			'We should have an exception thrown in this scenario'
@@ -88,7 +85,7 @@ private class TriggerActionFlowBypassTest {
 			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			myException.getMessage(),
 			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
@@ -26,8 +26,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 			new List<String>{ TriggerActionConstants.OBJECT_STRING }
 		);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			TriggerBase.isBypassed(MY_STRING),
 			'The Object should not be bypassed'
 		);
@@ -41,8 +40,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 			new List<String>{ TriggerActionConstants.APEX_STRING }
 		);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			MetadataTriggerHandler.isBypassed(MY_STRING),
 			'The Apex should be not bypassed'
 		);
@@ -56,8 +54,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 			new List<String>{ TriggerActionConstants.FLOW_STRING }
 		);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			TriggerActionFlow.isBypassed(MY_STRING),
 			'The Flow should not be bypassed'
 		);
@@ -75,7 +72,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			myException,
 			'We should have an exception thrown in this scenario'
@@ -85,7 +82,7 @@ private class TriggerActionFlowClearAllBypassesTest {
 			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			myException.getMessage(),
 			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
@@ -30,8 +30,7 @@ private class TriggerActionFlowClearBypassTest {
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			TriggerBase.isBypassed(MY_STRING),
 			'The Object should not be bypassed'
 		);
@@ -46,8 +45,7 @@ private class TriggerActionFlowClearBypassTest {
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			MetadataTriggerHandler.isBypassed(MY_STRING),
 			'The Apex should be not bypassed'
 		);
@@ -62,8 +60,7 @@ private class TriggerActionFlowClearBypassTest {
 
 		TriggerActionFlowClearBypass.clearBypass(requests);
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			TriggerActionFlow.isBypassed(MY_STRING),
 			'The Flow should not be bypassed'
 		);
@@ -81,7 +78,7 @@ private class TriggerActionFlowClearBypassTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			myException,
 			'We should have an exception thrown in this scenario'
@@ -91,7 +88,7 @@ private class TriggerActionFlowClearBypassTest {
 			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			myException.getMessage(),
 			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
@@ -29,12 +29,12 @@ private class TriggerActionFlowIsBypassedTest {
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			1,
 			isBypassed.size(),
 			'We should only have one result for our request'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			TriggerBase.isBypassed(MY_STRING),
 			isBypassed[0],
 			'The result should contain the same result as the TriggerBase'
@@ -49,12 +49,12 @@ private class TriggerActionFlowIsBypassedTest {
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			1,
 			isBypassed.size(),
 			'We should only have one result for our request'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			MetadataTriggerHandler.isBypassed(MY_STRING),
 			isBypassed[0],
 			'The result should contain the same result as the MetadataTriggerHandler'
@@ -69,12 +69,12 @@ private class TriggerActionFlowIsBypassedTest {
 
 		List<Boolean> isBypassed = TriggerActionFlowIsBypassed.isBypassed(requests);
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			1,
 			isBypassed.size(),
 			'We should only have one result for our request'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			TriggerActionFlow.isBypassed(MY_STRING),
 			isBypassed[0],
 			'The result should contain the same result as the TriggerActionFlow'
@@ -95,7 +95,7 @@ private class TriggerActionFlowIsBypassedTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(
+		System.Assert.areNotEqual(
 			null,
 			myException,
 			'We should have an exception thrown in this scenario'
@@ -105,7 +105,7 @@ private class TriggerActionFlowIsBypassedTest {
 			IllegalArgumentException.class,
 			'The exception should be of the correct type'
 		);
-		System.assertEquals(
+		System.Assert.areEqual(
 			myException.getMessage(),
 			TriggerActionConstants.INVALID_TYPE,
 			'The exeption should contain the message we are looking for'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -47,7 +47,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -62,7 +62,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -77,7 +77,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -92,7 +92,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -107,7 +107,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -122,7 +122,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -137,7 +137,7 @@ public class TriggerActionFlowTest {
 			myException = e;
 		}
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
@@ -148,7 +148,7 @@ public class TriggerActionFlowTest {
 	private static void bypassShouldSucceed() {
 		TriggerActionFlow.bypass(SAMPLE_FLOW_NAME);
 
-		System.assert(
+		System.Assert.isTrue(
 			TriggerActionFlow.bypassedFlows.contains(SAMPLE_FLOW_NAME),
 			'Static bypasses should be populated properly'
 		);
@@ -159,8 +159,8 @@ public class TriggerActionFlowTest {
 		TriggerActionFlow.bypass(SAMPLE_FLOW_NAME);
 		TriggerActionFlow.clearBypass(SAMPLE_FLOW_NAME);
 
-		System.assert(
-			!TriggerActionFlow.bypassedFlows.contains(SAMPLE_FLOW_NAME),
+		System.Assert.isFalse(
+			TriggerActionFlow.bypassedFlows.contains(SAMPLE_FLOW_NAME),
 			'Static bypasses should be populated properly'
 		);
 	}
@@ -172,8 +172,7 @@ public class TriggerActionFlowTest {
 
 		isBypassed = TriggerActionFlow.isBypassed(SAMPLE_FLOW_NAME);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			isBypassed,
 			'Static bypasses should be populated properly'
 		);
@@ -185,7 +184,7 @@ public class TriggerActionFlowTest {
 
 		TriggerActionFlow.clearAllBypasses();
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			0,
 			TriggerActionFlow.bypassedFlows.size(),
 			'Static bypasses should be populated properly'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
@@ -36,7 +36,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -45,7 +45,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -54,7 +54,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -63,7 +63,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -72,7 +72,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -81,7 +81,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -90,7 +90,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(true, base.executed, 'Run should be successful');
+		System.Assert.isTrue(base.executed, 'Run should be successful');
 	}
 
 	@IsTest
@@ -100,7 +100,7 @@ private class TriggerBaseTest {
 		base.run();
 		base.run();
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			2,
 			TriggerBase.idToNumberOfTimesSeenBeforeUpdate.get(MY_ACCOUNT.Id),
 			'The number of time seen should be populated properly'
@@ -114,7 +114,7 @@ private class TriggerBaseTest {
 		base.run();
 		base.run();
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			2,
 			TriggerBase.idToNumberOfTimesSeenAfterUpdate.get(MY_ACCOUNT.Id),
 			'The number of time seen should be populated properly'
@@ -129,8 +129,8 @@ private class TriggerBaseTest {
 			myException = e;
 		}
 
-		System.assertNotEquals(null, myException, 'An exception should be thrown');
-		System.assert(
+		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.isTrue(
 			myException.getMessage()
 				.contains(TriggerBase.HANDLER_OUTSIDE_TRIGGER_MESSAGE),
 			'The exception should be the one we are looking for'
@@ -145,8 +145,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.assertEquals(
-			false,
+		System.Assert.isFalse(
 			base.executed,
 			'The base should not have executed'
 		);
@@ -156,7 +155,7 @@ private class TriggerBaseTest {
 	private static void bypassShouldSucceed() {
 		TriggerBase.bypass(ACCOUNT);
 
-		System.assert(
+		System.Assert.isTrue(
 			TriggerBase.bypassedObjects.contains(ACCOUNT),
 			'The bypasses should be configured correctly'
 		);
@@ -168,8 +167,8 @@ private class TriggerBaseTest {
 
 		TriggerBase.clearBypass(ACCOUNT);
 
-		System.assert(
-			!TriggerBase.bypassedObjects.contains(ACCOUNT),
+		System.Assert.isFalse(
+			TriggerBase.bypassedObjects.contains(ACCOUNT),
 			'The bypasses should be configured correctly'
 		);
 	}
@@ -178,8 +177,7 @@ private class TriggerBaseTest {
 	private static void isBypassedShouldSucceed() {
 		TriggerBase.bypass(ACCOUNT);
 
-		System.assertEquals(
-			true,
+		System.Assert.isTrue(
 			TriggerBase.isBypassed(ACCOUNT),
 			'The bypasses should be configured correctly'
 		);
@@ -191,7 +189,7 @@ private class TriggerBaseTest {
 
 		TriggerBase.clearAllBypasses();
 
-		System.assertEquals(
+		System.Assert.areEqual(
 			0,
 			TriggerBase.bypassedObjects.size(),
 			'The bypasses should be configured correctly'

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/flows/TriggerActionFlowTest.flow-meta.xml
+++ b/trigger-actions-framework/main/default/flows/TriggerActionFlowTest.flow-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <assignments>
         <name>Set_Name</name>
         <label>Set Name</label>


### PR DESCRIPTION
Fixes #92 

## Change

- Update all meta.xml files and `sfdx-project.json` to api version 56.0
- Update `Ssytem.assert(!...)` to `System.Assert.isFalse`
- Update `System.assert` to `System.Assert.isTrue`
- Update `System.assertEquals(true, ...)` to `System.Assert.isTrue`
- Update `System.assertEquals(false, ...)` to `System.Assert.isFalse`
- Update `System.assertEquals` to `System.Assert.areEqual`

---

__Why not update `System.assertEquals/assertNotEqual(null, ...)` to `System.Assert.isNull/isNotNull`?__

System.assertEquals(null, ...) and System.assertNotEquals(null, ...) were not converted to System.Assert.isNull/isNotNull because they do not show the object's value in the logs on failure.  Instead, these were replaced with System.Assert.areEqual/areNotEqual shows the object's value in the logs.  I'm sure this will be fixed eventually but I didn't want to cause issues when troubleshooting tests are required.

---

- [x] Tests pass
- [x] Appropriate changes to README are included in PR *(None required)*
