### PR TITLE
Improve AddError | Suppress Certain PMD Rules | Format with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png" alt="Deploy to Salesforce" />
 </a>
 
-#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLDAA0)
+#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLIAA0)
 
-#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLDAA0)
+#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLIAA0)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
   <img src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png" alt="Deploy to Salesforce" />
 </a>
 
-#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaJqAAK)
+#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLDAA0)
 
-#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaJqAAK)
+#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t3h000004VaLDAA0)
 
 ---
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -19,6 +19,7 @@
 		"Trigger Actions Framework@0.1.4-0": "04t3h000004VaJWAA0",
 		"Trigger Actions Framework@0.1.4-1": "04t3h000004VaJbAAK",
 		"Trigger Actions Framework@0.1.5-0": "04t3h000004VaJqAAK",
-		"Trigger Actions Framework@0.1.6": "04t3h000004VaLDAA0"
+		"Trigger Actions Framework@0.1.6": "04t3h000004VaLDAA0",
+		"Trigger Actions Framework@0.1.7": "04t3h000004VaLIAA0"
 	}
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -18,6 +18,7 @@
 		"Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK",
 		"Trigger Actions Framework@0.1.4-0": "04t3h000004VaJWAA0",
 		"Trigger Actions Framework@0.1.4-1": "04t3h000004VaJbAAK",
-		"Trigger Actions Framework@0.1.5-0": "04t3h000004VaJqAAK"
+		"Trigger Actions Framework@0.1.5-0": "04t3h000004VaJqAAK",
+		"Trigger Actions Framework@0.1.6": "04t3h000004VaLDAA0"
 	}
 }

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-@SuppressWarnings('PMD.CognitiveComplexity')
+@SuppressWarnings('PMD.ApexDoc, PMD.CognitiveComplexity')
 public inherited sharing class MetadataTriggerHandler extends TriggerBase implements TriggerAction.BeforeInsert, TriggerAction.AfterInsert, TriggerAction.BeforeUpdate, TriggerAction.AfterUpdate, TriggerAction.BeforeDelete, TriggerAction.AfterDelete, TriggerAction.AfterUndelete {
 	@TestVisible
 	private static final String INVALID_TYPE_ERROR = 'Please check the Trigger Action Custom Metadata for the {1} context on the {2} sObject. The {0} class does not implement the Trigger Action interface specified for the {1} context.';

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
@@ -14,6 +14,9 @@
    limitations under the License.
  */
 
+@SuppressWarnings(
+	'PMD.ApexDoc, PMD.CyclomaticComplexity, PMD.ApexUnitTestClassShouldHaveRunAs'
+)
 @IsTest(isParallel=true)
 private class MetadataTriggerHandlerTest {
 	private static final String MY_ACCOUNT = 'My Account';
@@ -86,7 +89,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -120,7 +127,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -169,7 +180,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -201,7 +216,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -254,7 +273,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -288,7 +311,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -337,7 +364,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -369,7 +400,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -422,7 +457,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -456,7 +495,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -505,7 +548,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -537,7 +584,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -590,7 +641,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(
@@ -624,7 +679,11 @@ private class MetadataTriggerHandlerTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.areEqual(
 			myException.getMessage(),
 			String.format(

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerAction.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerAction.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.CyclomaticComplexity')
 public class TriggerAction {
 	public interface BeforeInsert {
 		void beforeInsert(List<SObject> newList);

--- a/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls
@@ -13,6 +13,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
+
+@SuppressWarnings('PMD.ApexDoc')
 public class TriggerActionConstants {
 	public static final String APEX_STRING = 'Apex';
 	public static final String FLOW_STRING = 'Flow';

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.CyclomaticComplexity')
 public inherited sharing class TriggerActionFlow implements TriggerAction.BeforeInsert, TriggerAction.AfterInsert, TriggerAction.BeforeUpdate, TriggerAction.AfterUpdate, TriggerAction.BeforeDelete, TriggerAction.AfterDelete, TriggerAction.AfterUndelete {
 	@TestVisible
 	private static Set<String> bypassedFlows = new Set<String>();
@@ -44,7 +45,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void beforeInsert(List<SObject> newList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		List<Invocable.Action.Result> results = invokeAction(
@@ -55,7 +56,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void afterInsert(List<SObject> newList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
@@ -67,7 +68,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void beforeUpdate(List<SObject> newList, List<SObject> oldList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
@@ -90,7 +91,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void afterUpdate(List<SObject> newList, List<SObject> oldList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
@@ -114,7 +115,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void beforeDelete(List<SObject> oldList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
@@ -129,7 +130,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void afterDelete(List<SObject> oldList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
@@ -144,7 +145,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 	}
 
 	public void afterUndelete(List<SObject> newList) {
-		if (thisFlowIsBypassed()) {
+		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
@@ -155,7 +156,7 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		);
 	}
 
-	private Boolean thisFlowIsBypassed() {
+	private Boolean flowIsBypassed() {
 		if (String.isBlank(flowName)) {
 			throw new IllegalArgumentException(
 				TriggerActionConstants.INVALID_FLOW_NAME
@@ -179,11 +180,29 @@ public inherited sharing class TriggerActionFlow implements TriggerAction.Before
 		sObject stateBeforeFlow,
 		sObject stateAfterFlow
 	) {
+		Boolean hasBeenMutated = false;
 		Map<String, Object> afterFlowMap = stateAfterFlow.getPopulatedFieldsAsMap();
 		for (String fieldName : afterFlowMap.keySet()) {
 			if (stateBeforeFlow.get(fieldName) != stateAfterFlow.get(fieldName)) {
 				stateBeforeFlow.put(fieldName, stateAfterFlow.get(fieldName));
+				hasBeenMutated = true;
 			}
+		}
+		/**
+		 * If the record is not mutated, then any errors will persist after the flow is complete,
+		 * so there is no need to re-add them
+		 */
+		if (hasBeenMutated == false) {
+			return;
+		}
+		for (Database.Error err : stateAfterFlow.getErrors()) {
+			/**
+			 * Unfortunately, err.getFields() does not include the field api name after
+			 * calling .addError(String fieldApiName, String message) from within a flow,
+			 * so when the record is mutated before save,
+			 * the exact field location for the error cannot be applied.
+			 */
+			stateBeforeFlow.addError(err.getMessage());
 		}
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc')
 public inherited sharing class TriggerActionFlowAddError {
 	@InvocableMethod(
 		category='Trigger Action Flow'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest
 private class TriggerActionFlowAddErrorTest {
 	private static final String MY_STRING = 'MY_STRING';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls
@@ -13,7 +13,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-@SuppressWarnings('PMD.CognitiveComplexity')
+
+@SuppressWarnings('PMD.ApexDoc, PMD.CognitiveComplexity')
 public inherited sharing class TriggerActionFlowBypass {
 	@InvocableMethod(
 		category='Trigger Action Flow'
@@ -23,10 +24,7 @@ public inherited sharing class TriggerActionFlowBypass {
 	public static void bypass(List<Request> requests) {
 		TriggerActionFlowBypassProcessor bypassProcessor = new FlowBypassProcessor();
 		for (Request myRequest : requests) {
-			bypassProcessor.execute(
-				myRequest.bypassType,
-				myRequest.name
-			);
+			bypassProcessor.execute(myRequest.bypassType, myRequest.name);
 		}
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls
@@ -13,12 +13,10 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-public inherited sharing abstract class TriggerActionFlowBypassProcessor {
 
-	public void execute(
-		String requestType,
-		String requestName
-	) {
+@SuppressWarnings('PMD.ApexDoc')
+public inherited sharing abstract class TriggerActionFlowBypassProcessor {
+	public void execute(String requestType, String requestName) {
 		if (!TriggerActionConstants.REQUEST_TYPES.contains(requestType)) {
 			throw new IllegalArgumentException(TriggerActionConstants.INVALID_TYPE);
 		} else if (requestType == TriggerActionConstants.FLOW_STRING) {

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest(isParallel=true)
 private class TriggerActionFlowBypassTest {
 	private static final String MY_STRING = 'MY_STRING';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-@SuppressWarnings('PMD.CognitiveComplexity')
+@SuppressWarnings('PMD.ApexDoc, PMD.CognitiveComplexity')
 public inherited sharing class TriggerActionFlowClearAllBypasses {
 	@InvocableMethod(
 		category='Trigger Action Flow'

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest(isParallel=true)
 private class TriggerActionFlowClearAllBypassesTest {
 	private static final String MY_STRING = 'MY_STRING';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-@SuppressWarnings('PMD.CognitiveComplexity')
+@SuppressWarnings('PMD.ApexDoc, PMD.CognitiveComplexity')
 public inherited sharing class TriggerActionFlowClearBypass {
 	@InvocableMethod(
 		category='Trigger Action Flow'
@@ -23,10 +23,7 @@ public inherited sharing class TriggerActionFlowClearBypass {
 	public static void clearBypass(List<Request> requests) {
 		TriggerActionFlowBypassProcessor bypassProcesser = new FlowClearBypassProcessor();
 		for (Request myRequest : requests) {
-			bypassProcesser.execute(
-				myRequest.bypassType,
-				myRequest.name
-			);
+			bypassProcesser.execute(myRequest.bypassType, myRequest.name);
 		}
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest
 private class TriggerActionFlowClearBypassTest {
 	private static final String MY_STRING = 'MY_STRING';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls
@@ -13,7 +13,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-@SuppressWarnings('PMD.CognitiveComplexity')
+@SuppressWarnings('PMD.ApexDoc, PMD.CognitiveComplexity')
 public inherited sharing class TriggerActionFlowIsBypassed {
 	@InvocableMethod(
 		category='Trigger Action Flow'
@@ -24,10 +24,7 @@ public inherited sharing class TriggerActionFlowIsBypassed {
 		List<Boolean> results = new List<Boolean>();
 		FlowIsBypassedProcesser bypassProcesser = new FlowIsBypassedProcesser();
 		for (Request myRequest : requests) {
-			bypassProcesser.execute(
-				myRequest.bypassType,
-				myRequest.name
-			);
+			bypassProcesser.execute(myRequest.bypassType, myRequest.name);
 			results.add(bypassProcesser.getHasBeenBypassed());
 		}
 		return results;

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest
 private class TriggerActionFlowIsBypassedTest {
 	private static final String MY_STRING = 'MY_STRING';

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest(isParallel=true)
 public class TriggerActionFlowTest {
 	private static final String MY_ACCOUNT = 'My Account';
@@ -52,6 +53,44 @@ public class TriggerActionFlowTest {
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
 		);
+		System.Assert.areEqual(
+			'Foo',
+			myAccount.Name,
+			'The name should be set from the flow'
+		);
+		System.Assert.areEqual(
+			true,
+			myAccount.hasErrors(),
+			'There should be an error added to the record'
+		);
+		System.Assert.areEqual(
+			1,
+			myAccount.getErrors().size(),
+			'There should be exactly one error'
+		);
+		System.Assert.areEqual(
+			'Test!',
+			myAccount.getErrors()[0].getMessage(),
+			'The message should be what we expect'
+		);
+	}
+
+	@IsTest
+	private static void beforeInsertShouldDoNothingWhenBypassed() {
+		TriggerActionFlow.bypass(SAMPLE_FLOW_NAME);
+
+		actionFlow.beforeInsert(newList);
+
+		System.Assert.areEqual(
+			MY_ACCOUNT,
+			myAccount.Name,
+			'The name should not be set from the flow'
+		);
+		System.Assert.areEqual(
+			false,
+			myAccount.hasErrors(),
+			'There should be no errors added to the record'
+		);
 	}
 
 	@IsTest
@@ -81,6 +120,44 @@ public class TriggerActionFlowTest {
 			null,
 			myException,
 			'There should be no exception thrown when this method is called with a valid flow.'
+		);
+		System.Assert.areEqual(
+			'Foo',
+			myAccount.Name,
+			'The name should be set from the flow'
+		);
+		System.Assert.areEqual(
+			true,
+			myAccount.hasErrors(),
+			'There should be an error added to the record'
+		);
+		System.Assert.areEqual(
+			1,
+			myAccount.getErrors().size(),
+			'There should be exactly one error'
+		);
+		System.Assert.areEqual(
+			'Test!',
+			myAccount.getErrors()[0].getMessage(),
+			'The message should be what we expect'
+		);
+	}
+
+	@IsTest
+	private static void beforeUpdateShouldDoNothingWhenBypassed() {
+		TriggerActionFlow.bypass(SAMPLE_FLOW_NAME);
+
+		actionFlow.beforeUpdate(newList, oldList);
+
+		System.Assert.areEqual(
+			MY_ACCOUNT,
+			myAccount.Name,
+			'The name should not be set from the flow'
+		);
+		System.Assert.areEqual(
+			false,
+			myAccount.hasErrors(),
+			'There should be no errors added to the record'
 		);
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls
@@ -14,6 +14,9 @@
    limitations under the License.
  */
 
+@SuppressWarnings(
+	'PMD.ApexDoc, PMD.StdCyclomaticComplexity, PMD.CyclomaticComplexity'
+)
 public inherited sharing virtual class TriggerBase {
 	@TestVisible
 	private static final String HANDLER_OUTSIDE_TRIGGER_MESSAGE = 'Trigger handler called outside of Trigger execution';

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc, PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest(isParallel=true)
 private class TriggerBaseTest {
 	private static final String ACCOUNT = 'Account';
@@ -129,7 +130,11 @@ private class TriggerBaseTest {
 			myException = e;
 		}
 
-		System.Assert.areNotEqual(null, myException, 'An exception should be thrown');
+		System.Assert.areNotEqual(
+			null,
+			myException,
+			'An exception should be thrown'
+		);
 		System.Assert.isTrue(
 			myException.getMessage()
 				.contains(TriggerBase.HANDLER_OUTSIDE_TRIGGER_MESSAGE),
@@ -145,10 +150,7 @@ private class TriggerBaseTest {
 
 		base.run();
 
-		System.Assert.isFalse(
-			base.executed,
-			'The base should not have executed'
-		);
+		System.Assert.isFalse(base.executed, 'The base should not have executed');
 	}
 
 	@IsTest

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls
@@ -14,6 +14,7 @@
    limitations under the License.
  */
 
+@SuppressWarnings('PMD.ApexDoc')
 @IsTest
 public class TriggerTestUtility {
 	static Integer myNumber = 1;

--- a/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>56.0</apiVersion>
     <status>Active</status>

--- a/trigger-actions-framework/main/default/flows/TriggerActionFlowTest.flow-meta.xml
+++ b/trigger-actions-framework/main/default/flows/TriggerActionFlowTest.flow-meta.xml
@@ -1,5 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <actionCalls>
+        <name>Add_Error</name>
+        <label>Add Error</label>
+        <locationX>176</locationX>
+        <locationY>278</locationY>
+        <actionName>TriggerActionFlowAddError</actionName>
+        <actionType>apex</actionType>
+        <dataTypeMappings>
+            <typeName>T__record</typeName>
+            <typeValue>Account</typeValue>
+        </dataTypeMappings>
+        <flowTransactionModel>CurrentTransaction</flowTransactionModel>
+        <inputParameters>
+            <name>errorMessage</name>
+            <value>
+                <stringValue>Test!</stringValue>
+            </value>
+        </inputParameters>
+        <inputParameters>
+            <name>record</name>
+            <value>
+                <elementReference>record</elementReference>
+            </value>
+        </inputParameters>
+    </actionCalls>
     <apiVersion>56.0</apiVersion>
     <assignments>
         <name>Set_Name</name>
@@ -13,10 +38,15 @@
                 <stringValue>Foo</stringValue>
             </value>
         </assignmentItems>
+        <connector>
+            <targetReference>Add_Error</targetReference>
+        </connector>
     </assignments>
-    <description>This is meant for test coverage for the TriggerActionFlow class.</description>
+    <description
+	>This is meant for test coverage for the TriggerActionFlow class.</description>
     <environments>Default</environments>
-    <interviewLabel>TriggerActionFlowTest {!$Flow.CurrentDateTime}</interviewLabel>
+    <interviewLabel
+	>TriggerActionFlowTest {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Trigger Action Flow Test</label>
     <processMetadataValues>
         <name>BuilderType</name>

--- a/trigger-actions-framework/main/default/layouts/Trigger_Action__mdt-Trigger Action Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/Trigger_Action__mdt-Trigger Action Layout.layout-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <layoutSections>
         <customLabel>false</customLabel>

--- a/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
     <layoutSections>
         <customLabel>false</customLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/Trigger_Action__mdt.object-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/Trigger_Action__mdt.object-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <label>Trigger Action</label>
     <pluralLabel>Trigger Actions</pluralLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Delete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Delete__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>After_Delete__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the after delete context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the after delete context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the after delete context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the after delete context</inlineHelpText>
     <label>After Delete</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>After Delete</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Insert__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Insert__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>After_Insert__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the after insert context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the after insert context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the after insert context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the after insert context</inlineHelpText>
     <label>After Insert</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>After Insert</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Undelete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Undelete__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>After_Undelete__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the after undelete context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the after undelete context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the after undelete context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the after undelete context</inlineHelpText>
     <label>After Undelete</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>After Undelete</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Update__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Update__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>After_Update__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the after update context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the after update context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the after update context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the after update context</inlineHelpText>
     <label>After Update</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>After Update</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Allow_Flow_Recursion__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Allow_Flow_Recursion__c.field-meta.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Allow_Flow_Recursion__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>Check this box to allow the flow to execute recursively</description>
+    <description
+	>Check this box to allow the flow to execute recursively</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Check this box to allow the flow to execute recursively</inlineHelpText>
+    <inlineHelpText
+	>Check this box to allow the flow to execute recursively</inlineHelpText>
     <label>Allow Flow Recursion?</label>
     <type>Checkbox</type>
 </CustomField>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Name__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Apex_Class_Name__c</fullName>
-    <description>Enter the name of the Apex Class which defines the action to be taken</description>
+    <description
+	>Enter the name of the Apex Class which defines the action to be taken</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the Apex Class which defines the action to be taken</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the Apex Class which defines the action to be taken</inlineHelpText>
     <label>Apex Class Name</label>
     <length>255</length>
     <required>true</required>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Delete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Delete__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Before_Delete__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the before delete context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the before delete context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the before delete context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the before delete context</inlineHelpText>
     <label>Before Delete</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>Before Delete</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Insert__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Insert__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Before_Insert__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the before insert context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the before insert context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the before insert context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the before insert context</inlineHelpText>
     <label>Before Insert</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>Before Insert</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Update__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Update__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Before_Update__c</fullName>
-    <description>Enter the name of the sObject you want to have this action execute on during the before update context</description>
+    <description
+	>Enter the name of the sObject you want to have this action execute on during the before update context</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of the sObject you want to have this action execute on during the before update context</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of the sObject you want to have this action execute on during the before update context</inlineHelpText>
     <label>Before Update</label>
     <referenceTo>sObject_Trigger_Setting__mdt</referenceTo>
     <relationshipLabel>Before Update</relationshipLabel>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Bypass_Execution__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>Set this to true to bypass this Trigger Action from being called</description>
+    <description
+	>Set this to true to bypass this Trigger Action from being called</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
+    <inlineHelpText
+	>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
     <label>Bypass Execution</label>
     <type>Checkbox</type>
 </CustomField>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Bypass_Permission__c</fullName>
-    <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
+    <description
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
+    <inlineHelpText
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Description__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Description__c.field-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Description__c</fullName>
     <externalId>false</externalId>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Flow_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Flow_Name__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Flow_Name__c</fullName>
-    <description>Enter the name of a flow you would like to execute. The flow name specified must have two resources called &quot;newList&quot; and &quot;oldList&quot; which are collections of sObjects to work properly.</description>
+    <description
+	>Enter the name of a flow you would like to execute. The flow name specified must have two resources called &quot;newList&quot; and &quot;oldList&quot; which are collections of sObjects to work properly.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the name of a flow you would like to execute. The flow name specified must have two resources called &quot;newList&quot; and &quot;oldList&quot; which are collections of sObjects to work properly.</inlineHelpText>
+    <inlineHelpText
+	>Enter the name of a flow you would like to execute. The flow name specified must have two resources called &quot;newList&quot; and &quot;oldList&quot; which are collections of sObjects to work properly.</inlineHelpText>
     <label>Flow Name</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Order__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Order__c.field-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Order__c</fullName>
     <externalId>false</externalId>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Required_Permission__c</fullName>
-    <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
+    <description
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
+    <inlineHelpText
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Description_is_Required.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Description_is_Required.validationRule-meta.xml
@@ -1,9 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Description_is_Required</fullName>
     <active>true</active>
-    <description>You must enter a description for this Trigger Action.</description>
+    <description
+	>You must enter a description for this Trigger Action.</description>
     <errorConditionFormula>ISBLANK(Description__c)</errorConditionFormula>
     <errorDisplayField>Description__c</errorDisplayField>
-    <errorMessage>You must enter a description for this Trigger Action.</errorMessage>
+    <errorMessage
+	>You must enter a description for this Trigger Action.</errorMessage>
 </ValidationRule>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Flow_Name.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Flow_Name.validationRule-meta.xml
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Flow_Name</fullName>
     <active>true</active>
-    <errorConditionFormula>NOT(ISBLANK( Flow_Name__c ))  &amp;&amp;  Apex_Class_Name__c != &quot;TriggerActionFlow&quot;</errorConditionFormula>
-    <errorMessage>The Apex Class Name must equal &quot;TriggerActionFlow&quot; if the Flow Name is populated.</errorMessage>
+    <errorConditionFormula
+	>NOT(ISBLANK( Flow_Name__c ))  &amp;&amp;  Apex_Class_Name__c != &quot;TriggerActionFlow&quot;</errorConditionFormula>
+    <errorMessage
+	>The Apex Class Name must equal &quot;TriggerActionFlow&quot; if the Flow Name is populated.</errorMessage>
 </ValidationRule>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Must_Choose_A_Context.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Must_Choose_A_Context.validationRule-meta.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Must_Choose_A_Context</fullName>
     <active>false</active>
-    <description>Throws an error if the user does not choose at least one context</description>
+    <description
+	>Throws an error if the user does not choose at least one context</description>
     <errorConditionFormula>ISBLANK(Before_Insert__c)
 &amp;&amp;
 ISBLANK(After_Insert__c)

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Only_One_Context.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Only_One_Context.validationRule-meta.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Only_One_Context</fullName>
     <active>true</active>
-    <description>Throws an error if the user selects more than one context.</description>
+    <description
+	>Throws an error if the user selects more than one context.</description>
     <errorConditionFormula>OR(
 	NOT(ISBLANK(Before_Insert__c)) &amp;&amp;
 	OR(

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Recursion_Only_For_Flows.validationRule-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/validationRules/Recursion_Only_For_Flows.validationRule-meta.xml
@@ -1,8 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Recursion_Only_For_Flows</fullName>
     <active>true</active>
-    <description>Throws an error if the &quot;Allow Flow Recursion&quot; checkbox is checked without a &quot;Flow Name&quot;.</description>
-    <errorConditionFormula>Allow_Flow_Recursion__c == true &amp;&amp; ISBLANK( Flow_Name__c )</errorConditionFormula>
-    <errorMessage>You can only mark &quot;Allow Flow Recursion&quot; checkbox as &quot;True&quot; when you have a value for &quot;Flow Name&quot;.</errorMessage>
+    <description
+	>Throws an error if the &quot;Allow Flow Recursion&quot; checkbox is checked without a &quot;Flow Name&quot;.</description>
+    <errorConditionFormula
+	>Allow_Flow_Recursion__c == true &amp;&amp; ISBLANK( Flow_Name__c )</errorConditionFormula>
+    <errorMessage
+	>You can only mark &quot;Allow Flow Recursion&quot; checkbox as &quot;True&quot; when you have a value for &quot;Flow Name&quot;.</errorMessage>
 </ValidationRule>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -1,11 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Bypass_Execution__c</fullName>
     <defaultValue>false</defaultValue>
-    <description>Set this to true to bypass all Trigger Actions from being called on this sObject</description>
+    <description
+	>Set this to true to bypass all Trigger Actions from being called on this sObject</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Set this to true to bypass all Trigger Actions from being called on this sObject</inlineHelpText>
+    <inlineHelpText
+	>Set this to true to bypass all Trigger Actions from being called on this sObject</inlineHelpText>
     <label>Bypass Execution</label>
     <type>Checkbox</type>
 </CustomField>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Bypass_Permission__c</fullName>
-    <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
+    <description
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
+    <inlineHelpText
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_API_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_API_Name__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Object_API_Name__c</fullName>
-    <description>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</description>
+    <description
+	>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</inlineHelpText>
+    <inlineHelpText
+	>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</inlineHelpText>
     <label>Object API Name</label>
     <length>255</length>
     <required>true</required>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_Namespace__c.field-meta.xml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Object_Namespace__c</fullName>
     <description>Enter the namespace object for this trigger.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Enter the namespace object for this trigger.</inlineHelpText>
+    <inlineHelpText
+	>Enter the namespace object for this trigger.</inlineHelpText>
     <label>Object Namespace</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
@@ -1,10 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Required_Permission__c</fullName>
-    <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</description>
+    <description
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
     <fieldManageability>DeveloperControlled</fieldManageability>
-    <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</inlineHelpText>
+    <inlineHelpText
+	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
     <length>255</length>
     <required>false</required>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/sObject_Trigger_Setting__mdt.object-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/sObject_Trigger_Setting__mdt.object-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
     <label>sObject Trigger Setting</label>
     <pluralLabel>sObject Trigger Settings</pluralLabel>


### PR DESCRIPTION
*Improve AddError* #40
- Copy errors back to `Trigger.new` elements when fields have been mutated (`TriggerActionFlow.applyFlowValues`).
- Update the `TriggerActionFlowTest` to actually call `AddError` invocable ([screenshot](https://snipboard.io/5zq02E.jpg))
- Change naming from `thisFlowIsBypassed` to `flowIsBypassed` for clarity

*PMD* #96
- Suppress certain PMD rules such as `PMD.ApexDoc`, `PMD.ApexUnitTestClassShouldHaveRunAs` and `PMD.CyclomaticComplexity`
- Executing PMD with default ruleset now produces 0 findings

*Prettier*
- Format all files using Prettier

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
