### PR TITLE
Clickable records in SObject Trigger Setting related lists

### DIFF
--- a/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
@@ -88,7 +88,7 @@
         <style>CustomLinks</style>
     </layoutSections>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -98,7 +98,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -108,7 +108,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -118,7 +118,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -128,7 +128,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -138,7 +138,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>
@@ -148,7 +148,7 @@
         <sortOrder>Asc</sortOrder>
     </relatedLists>
     <relatedLists>
-        <fields>DeveloperName</fields>
+        <fields>MasterLabel</fields>
         <fields>Apex_Class_Name__c</fields>
         <fields>Flow_Name__c</fields>
         <fields>Description__c</fields>


### PR DESCRIPTION
Previously the only links to related Trigger Actions under an SObject Trigger Setting were "Edit" and "Del". There was no quick way to open a TA for read (useful when you want to clone one). By replacing dev names by labels, we make the related TA clickable.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
