### PR TITLE
Safer type.forName

### DIFF
--- a/trigger-actions-framework/main/default/classes/FinalizerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/FinalizerHandler.cls
@@ -127,11 +127,20 @@ public with sharing virtual class FinalizerHandler {
 	) {
 		Object dynamicInstance;
 		String className = finalizerMetadata.Apex_Class_Name__c;
+		String namespace = finalizerMetadata.Apex_Class_Namespace__c;
 		if (FinalizerHandler.isBypassed(className)) {
 			return;
 		}
+
 		try {
-			dynamicInstance = Type.forName(className).newInstance();
+			try {
+                dynamicInstance = Type.forName(namespace, className).newInstance();
+            } catch (Exception e) {
+                // fallback to package namespace to not break existing implementations that are distributed in a namespace
+				String[] parts = String.valueOf(FinalizerHandler.class).split('\\.', 2);
+				namespace = parts.size() == 2 ? parts[0] : '';
+                dynamicInstance = Type.forName(namespace, className).newInstance();
+            }
 		} catch (System.NullPointerException e) {
 			handleFinalizerException(INVALID_CLASS_ERROR_FINALIZER, className);
 		}

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
@@ -86,6 +86,7 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 	private static final String QUERY_TEMPLATE = String.join(
 		new List<String>{
 			'SELECT Apex_Class_Name__c,',
+			'Apex_Class_Namespace__c,',
 			'Order__c,',
 			'Flow_Name__c,',
 			'Bypass_Permission__c,',
@@ -385,8 +386,15 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 		for (Trigger_Action__mdt triggerMetadata : actionMetadata) {
 			Object triggerAction;
 			try {
-				triggerAction = Type.forName(triggerMetadata.Apex_Class_Name__c)
-					.newInstance();
+				String namespace = triggerMetadata.Apex_Class_Namespace__c;
+                try {
+                    triggerAction = Type.forName(namespace, triggerMetadata.Apex_Class_Name__c).newInstance();
+                } catch (Exception e) {
+                    // fallback to package namespace to not break existing implementations that are distributed in a namespace
+					String[] parts = String.valueOf(MetadataTriggerHandler.class).split('\\.', 2);
+                	namespace = parts.size() == 2 ? parts[0] : '';
+                    triggerAction = Type.forName(namespace, triggerMetadata.Apex_Class_Name__c).newInstance();
+                }
 				if (triggerMetadata.Flow_Name__c != null) {
 					((TriggerActionFlow) triggerAction)
 						.flowName = triggerMetadata.Flow_Name__c;

--- a/trigger-actions-framework/main/default/layouts/DML_Finalizer__mdt-DML Finalizer Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/DML_Finalizer__mdt-DML Finalizer Layout.layout-meta.xml
@@ -34,6 +34,10 @@
         <label>Finalizer Configuration</label>
         <layoutColumns>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Apex_Class_Namespace__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Required</behavior>
                 <field>Apex_Class_Name__c</field>
             </layoutItems>

--- a/trigger-actions-framework/main/default/layouts/Trigger_Action__mdt-Trigger Action Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/Trigger_Action__mdt-Trigger Action Layout.layout-meta.xml
@@ -34,6 +34,10 @@
         <label>Trigger Action Information</label>
         <layoutColumns>
             <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Apex_Class_Namespace__c</field>
+            </layoutItems>
+            <layoutItems>
                 <behavior>Required</behavior>
                 <field>Apex_Class_Name__c</field>
             </layoutItems>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Apex_Class_Namespace__c</fullName>
+    <description>Enter the apex class namespace</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Enter the apex class namespace</inlineHelpText>
+    <label>Apex Class Namespace</label>
+    <length>15</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Apex_Class_Namespace__c</fullName>
     <description>Enter the apex class namespace</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Enter the apex class namespace</inlineHelpText>
     <label>Apex Class Namespace</label>
     <length>15</length>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Apex_Class_Namespace__c</fullName>
+    <description>Enter the apex class namespace</description>
+    <externalId>false</externalId>
+    <fieldManageability>DeveloperControlled</fieldManageability>
+    <inlineHelpText>Enter the apex class namespace</inlineHelpText>
+    <label>Apex Class Namespace</label>
+    <length>15</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Namespace__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Apex_Class_Namespace__c</fullName>
     <description>Enter the apex class namespace</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Enter the apex class namespace</inlineHelpText>
     <label>Apex Class Namespace</label>
     <length>15</length>


### PR DESCRIPTION
If packaged, Actions and Finalizers use an API that cannot access classes outside of the same package. Salesforce Documentation on the Type.forName warns of this and suggests using an alternative API https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_type.htm#apex_System_Type_forName

This adds new Apex_Class_Namespace fields and uses the more explicit and safer version of Type.ForName. I also included a fallback to make sure no existing functionality is lost.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
