### PR TITLE
Reduce field size

### DIFF
--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Apex_Class_Name__c.field-meta.xml
@@ -4,7 +4,7 @@
     <caseSensitive>false</caseSensitive>
     <description>Enter the name of the Apex Class which defines the action to be taken</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Enter the name of the Apex Class which defines the action to be taken</inlineHelpText>
     <label>Apex Class Name</label>
     <length>255</length>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>false</defaultValue>
     <description>Set this to true to bypass this Trigger Action from being called</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
     <label>Bypass Execution</label>
     <type>Checkbox</type>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -3,10 +3,10 @@
     <fullName>Bypass_Permission__c</fullName>
     <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Order__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Order__c.field-meta.xml
@@ -2,11 +2,11 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Order__c</fullName>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <label>Order</label>
-    <precision>18</precision>
+    <precision>6</precision>
     <required>true</required>
-    <scale>3</scale>
+    <scale>2</scale>
     <type>Number</type>
     <unique>false</unique>
 </CustomField>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Required_Permission__c.field-meta.xml
@@ -3,10 +3,10 @@
     <fullName>Required_Permission__c</fullName>
     <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Delete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Delete__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the after delete context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the after delete context</inlineHelpText>
     <label>After Delete</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Insert__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Insert__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the after insert context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the after insert context</inlineHelpText>
     <label>After Insert</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Undelete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Undelete__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the after undelete context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the after undelete context</inlineHelpText>
     <label>After Undelete</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Update__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/After_Update__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the after update context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the after update context</inlineHelpText>
     <label>After Update</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Allow_Flow_Recursion__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Allow_Flow_Recursion__c.field-meta.xml
@@ -5,7 +5,7 @@
     <description
 	>Check this box to allow the flow to execute recursively</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Check this box to allow the flow to execute recursively</inlineHelpText>
     <label>Allow Flow Recursion?</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Apex_Class_Name__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the Apex Class which defines the action to be taken</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the Apex Class which defines the action to be taken</inlineHelpText>
     <label>Apex Class Name</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Delete__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Delete__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the before delete context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the before delete context</inlineHelpText>
     <label>Before Delete</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Insert__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Insert__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the before insert context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the before insert context</inlineHelpText>
     <label>Before Insert</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Update__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Before_Update__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Enter the name of the sObject you want to have this action execute on during the before update context</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the name of the sObject you want to have this action execute on during the before update context</inlineHelpText>
     <label>Before Update</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -5,7 +5,7 @@
     <description
 	>Set this to true to bypass this Trigger Action from being called</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
     <label>Bypass Execution</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Description__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Description__c.field-meta.xml
@@ -2,7 +2,7 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Description__c</fullName>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <label>Description</label>
     <length>32768</length>
     <type>LongTextArea</type>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Flow_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Flow_Name__c.field-meta.xml
@@ -4,11 +4,11 @@
     <description
 	>Enter the API name of the flow you would like to execute.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the API name of the flow you would like to execute.</inlineHelpText>
     <label>Flow Name</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Order__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Order__c.field-meta.xml
@@ -2,11 +2,11 @@
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>Order__c</fullName>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <label>Order</label>
-    <precision>18</precision>
+    <precision>6</precision>
     <required>true</required>
-    <scale>3</scale>
+    <scale>2</scale>
     <type>Number</type>
     <unique>false</unique>
 </CustomField>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
@@ -4,11 +4,11 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -5,7 +5,7 @@
     <description
 	>Set this to true to bypass all Trigger Actions from being called on this sObject</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Set this to true to bypass all Trigger Actions from being called on this sObject</inlineHelpText>
     <label>Bypass Execution</label>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -4,11 +4,11 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_API_Name__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_API_Name__c.field-meta.xml
@@ -4,11 +4,11 @@
     <description
 	>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the API Name of the object for this trigger. If this object is part of a managed package, do not include the prefix.</inlineHelpText>
     <label>Object API Name</label>
-    <length>255</length>
+    <length>40</length>
     <required>true</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_Namespace__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Object_Namespace__c.field-meta.xml
@@ -3,11 +3,11 @@
     <fullName>Object_Namespace__c</fullName>
     <description>Enter the namespace object for this trigger.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Enter the namespace object for this trigger.</inlineHelpText>
     <label>Object Namespace</label>
-    <length>255</length>
+    <length>15</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
@@ -4,11 +4,11 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
-    <length>255</length>
+    <length>97</length>
     <required>false</required>
     <type>Text</type>
     <unique>false</unique>


### PR DESCRIPTION
Custom Metadata Types have a small (10Mb) limit for the total amount you can store in the records. Storage usage is determined by a fixed per record size that is affected by the field size.

Current field size is set to the max for all field types. However, several fields reference API names which have documented max lengths they can be in Salesforce. Any field size greater than this is "wasted" storage as it will never be needed.

**Changes**
- Reduced fields referencing Salesforce APIs to the maximum allowed API Name length for the type
- Updated fieldManagability to SubscriberControlled so that the framework could be included in a managed package.



- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR
