### PR TITLE
Make permission checks namespace safe

### DIFF
--- a/trigger-actions-framework/main/default/classes/ActionUtility.cls
+++ b/trigger-actions-framework/main/default/classes/ActionUtility.cls
@@ -1,0 +1,75 @@
+/**
+ * Utilities for managing actions.
+ *
+ * Allows for the retrieval of the current user's permissions only once during the entire transaction
+ * Consolidates code that is shared between MetadataTriggerHandler and FinalizerHandler classes
+ */
+
+public with sharing class ActionUtility {
+    @TestVisible
+    public static Set<String> userPermissions {
+        get {
+            if (userPermissions == null) {
+                userPermissions = new Set<String>();
+
+                List<PermissionSetAssignment> permSets = [
+                    SELECT AssigneeId, Assignee.FirstName, PermissionSetId, PermissionSet.Name
+                    FROM PermissionSetAssignment
+                    WHERE AssigneeId = :UserInfo.getUserId()
+                ];
+                Set<Id> permSetIds = new Set<Id>();
+                for (PermissionSetAssignment psa : permSets) {
+                    permSetIds.add(psa.PermissionSetId);
+                }
+                List<CustomPermission> customPerms = [
+                    SELECT DeveloperName, MasterLabel, NamespacePrefix
+                    FROM CustomPermission
+                    WHERE Id IN (SELECT SetupEntityId FROM SetupEntityAccess WHERE ParentId IN :permSetIds)
+                ];
+                for (CustomPermission cp : customPerms) {
+                    String qualifiedPerm = String.isBlank(cp.NamespacePrefix)
+                        ? cp.DeveloperName
+                        : cp.NamespacePrefix + '__' + cp.DeveloperName;
+                    userPermissions.add(qualifiedPerm);
+                }
+            }
+            return userPermissions;
+        }
+        private set;
+    }
+
+    public static boolean isNotBypassed(String requiredPermission, String bypassPermission) {
+        return !((requiredPermission != null && userPermissions.contains(requiredPermission)) ||
+        (bypassPermission != null && !userPermissions.contains(bypassPermission)));
+    }
+
+    public static Object getActionInstance(String className) {
+        String namespace = '';
+        System.Type actionType = Type.forName(className);
+        /** Type.forName(fullyQualifiedName) allowed some messyness and ambiguity in dealing with namespace
+         *   If config does not provide the correct namespace (likely if upgrading from older versions of this framework) we need to fallback in two scenarios
+         *     - package and class namespaced but namespace wasn't specified
+         *     - namespace is actually in the class field in the form namespace.classname
+         */
+        // try shared Namespace
+        if (actionType == null) {
+            // Get the namespace of the current class.
+            String[] parts = String.valueOf(ActionUtility.class).split('\\.', 2);
+            namespace = parts.size() == 2 ? parts[0] : '';
+
+            // try again with the new namespace
+            actionType = Type.forName(namespace, className);
+        }
+        // try namespace in Class_Name field
+        if (actionType == null) {
+            String[] parts = className.split('\\.', 2);
+            if (parts.size() == 2) {
+                namespace = parts[0];
+                className = parts[1];
+                actionType = Type.forName(namespace, className);
+            }
+        }
+        Object dynamicInstance = actionType.newInstance();
+        return dynamicInstance;
+    }
+}

--- a/trigger-actions-framework/main/default/classes/ActionUtility.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/ActionUtility.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/trigger-actions-framework/main/default/classes/FinalizerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/FinalizerHandler.cls
@@ -58,9 +58,6 @@ public with sharing virtual class FinalizerHandler {
 	@TestVisible
 	private static Set<String> bypassedFinalizers = new Set<String>();
 
-	@TestVisible
-	private static Map<String, Boolean> permissionMap = new Map<String, Boolean>();
-
 	/**
 	 * @description Bypass the execution of a specific finalizer.
 	 * @param finalizer The name of the finalizer to bypass.
@@ -103,10 +100,8 @@ public with sharing virtual class FinalizerHandler {
 			if (finalizerMetadata.Bypass_Execution__c) {
 				return;
 			}
-			populatePermissionMap(finalizerMetadata.Bypass_Permission__c);
-			populatePermissionMap(finalizerMetadata.Required_Permission__c);
 			if (
-				isNotBypassed(
+				ActionUtility.isNotBypassed(
 					finalizerMetadata.Bypass_Permission__c,
 					finalizerMetadata.Required_Permission__c
 				)
@@ -131,7 +126,7 @@ public with sharing virtual class FinalizerHandler {
 			return;
 		}
 		try {
-			dynamicInstance = Type.forName(className).newInstance();
+			dynamicInstance = ActionUtility.getActionInstance(className);
 		} catch (System.NullPointerException e) {
 			handleFinalizerException(INVALID_CLASS_ERROR_FINALIZER, className);
 		}
@@ -169,34 +164,6 @@ public with sharing virtual class FinalizerHandler {
 		throw new FinalizerException(
 			String.format(errorFormat, new List<String>{ className })
 		);
-	}
-
-	/**
-	 * @description Check if the finalizer is not bypassed.
-	 * @param requiredPermission The required permission.
-	 * @param bypassPermission The bypass permission.
-	 * @return True if the finalizer is not bypassed, false otherwise.
-	 */
-	private boolean isNotBypassed(
-		String requiredPermission,
-		String bypassPermission
-	) {
-		return !((requiredPermission != null &&
-		permissionMap.get(requiredPermission)) ||
-		(bypassPermission != null && !permissionMap.get(bypassPermission)));
-	}
-
-	/**
-	 * @description Populate the permission map.
-	 * @param permissionName The permission name.
-	 */
-	private void populatePermissionMap(String permissionName) {
-		if (permissionName != null && !permissionMap.containsKey(permissionName)) {
-			permissionMap.put(
-				permissionName,
-				FeatureManagement.checkPermission(permissionName)
-			);
-		}
 	}
 
 	@TestVisible

--- a/trigger-actions-framework/main/default/classes/FinalizerHandlerTest.cls
+++ b/trigger-actions-framework/main/default/classes/FinalizerHandlerTest.cls
@@ -119,7 +119,7 @@ private with sharing class FinalizerHandlerTest {
 			)
 		};
 
-		FinalizerHandler.permissionMap.put(BYPASS_PERMISSION, true);
+		ActionUtility.userPermissions.add(BYPASS_PERMISSION);
 		handler.handleDynamicFinalizers();
 
 		System.Assert.isTrue(
@@ -138,7 +138,7 @@ private with sharing class FinalizerHandlerTest {
 			)
 		};
 
-		FinalizerHandler.permissionMap.put(REQUIRED_PERMISSION, false);
+		ActionUtility.userPermissions = new Set<String>();
 		handler.handleDynamicFinalizers();
 
 		System.Assert.isTrue(

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
@@ -109,8 +109,6 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 	private static Set<String> bypassedActions = new Set<String>();
 	@TestVisible
 	private static Selector selector = new Selector();
-	@TestVisible
-	private static Map<String, Boolean> permissionMap = new Map<String, Boolean>();
 	private static Map<String, Map<String, List<Trigger_Action__mdt>>> sObjectToContextToActions = new Map<String, Map<String, List<Trigger_Action__mdt>>>();
 	@TestVisible
 	private static FinalizerHandler finalizerHandler = new FinalizerHandler();
@@ -226,20 +224,6 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 	}
 
 	/**
-	 * @description Populate the permission map.
-	 *
-	 * @param permissionName The name of the permission to check.
-	 */
-	private void populatePermissionMap(String permissionName) {
-		if (permissionName != null && !permissionMap.containsKey(permissionName)) {
-			permissionMap.put(
-				permissionName,
-				FeatureManagement.checkPermission(permissionName)
-			);
-		}
-	}
-
-	/**
 	 * @description Get the Trigger Action metadata.
 	 *
 	 * @param relationshipName The name of the relationship to get the metadata for.
@@ -311,38 +295,12 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 				relationshipName + RELATIONSHIP_SUFFIX
 			))
 			.get(sObject_Trigger_Setting__mdt.Required_Permission__c);
-		for (
-			String permissionName : new List<String>{
-				actionMetadata.Bypass_Permission__c,
-				actionMetadata.Required_Permission__c,
-				sObjectBypassPermissionName,
-				sObjectRequiredPermissionName
-			}
-		) {
-			populatePermissionMap(permissionName);
-		}
 
-		return isNotBypassed(
+		return ActionUtility.isNotBypassed(
 				actionMetadata.Bypass_Permission__c,
 				actionMetadata.Required_Permission__c
 			) &&
-			isNotBypassed(sObjectBypassPermissionName, sObjectRequiredPermissionName);
-	}
-
-	/**
-	 * @description Check if the Trigger Action is not bypassed.
-	 *
-	 * @param requiredPermission The required permission for the Trigger Action.
-	 * @param bypassPermission The bypass permission for the Trigger Action.
-	 * @return True if the Trigger Action is not bypassed, false otherwise.
-	 */
-	private static boolean isNotBypassed(
-		String requiredPermission,
-		String bypassPermission
-	) {
-		return !((requiredPermission != null &&
-		permissionMap.get(requiredPermission)) ||
-		(bypassPermission != null && !permissionMap.get(bypassPermission)));
+			ActionUtility.isNotBypassed(sObjectBypassPermissionName, sObjectRequiredPermissionName);
 	}
 
 	/**
@@ -385,8 +343,7 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 		for (Trigger_Action__mdt triggerMetadata : actionMetadata) {
 			Object triggerAction;
 			try {
-				triggerAction = Type.forName(triggerMetadata.Apex_Class_Name__c)
-					.newInstance();
+				triggerAction = ActionUtility.getActionInstance(triggerMetadata.Apex_Class_Name__c);
 				if (triggerMetadata.Flow_Name__c != null) {
 					((TriggerActionFlow) triggerAction)
 						.flowName = triggerMetadata.Flow_Name__c;

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
@@ -626,7 +626,7 @@ private class MetadataTriggerHandlerTest {
 			new List<SObject>{ action }
 		);
 
-		MetadataTriggerHandler.permissionMap.clear();
+		ActionUtility.userPermissions = new Set<String>();
 
 		handler.beforeInsert(handler.triggerNew);
 
@@ -641,7 +641,7 @@ private class MetadataTriggerHandlerTest {
 			new List<SObject>{ action }
 		);
 
-		MetadataTriggerHandler.permissionMap.clear();
+		ActionUtility.userPermissions = new Set<String>();
 
 		handler.beforeInsert(handler.triggerNew);
 
@@ -654,9 +654,7 @@ private class MetadataTriggerHandlerTest {
 		MetadataTriggerHandler.selector = new FakeSelector(
 			new List<SObject>{ action }
 		);
-		MetadataTriggerHandler.permissionMap = new Map<String, Boolean>{
-			REQUIRED_PERMISSION => false
-		};
+		ActionUtility.userPermissions = new Set<String>();
 
 		handler.beforeInsert(handler.triggerNew);
 
@@ -669,9 +667,7 @@ private class MetadataTriggerHandlerTest {
 		MetadataTriggerHandler.selector = new FakeSelector(
 			new List<SObject>{ action }
 		);
-		MetadataTriggerHandler.permissionMap = new Map<String, Boolean>{
-			REQUIRED_PERMISSION => false
-		};
+		ActionUtility.userPermissions = new Set<String>();
 
 		handler.beforeInsert(handler.triggerNew);
 
@@ -684,9 +680,7 @@ private class MetadataTriggerHandlerTest {
 		MetadataTriggerHandler.selector = new FakeSelector(
 			new List<SObject>{ action }
 		);
-		MetadataTriggerHandler.permissionMap = new Map<String, Boolean>{
-			BYPASS_PERMISSION => true
-		};
+		ActionUtility.userPermissions = new Set<String>{BYPASS_PERMISSION};
 
 		handler.beforeInsert(handler.triggerNew);
 
@@ -699,9 +693,7 @@ private class MetadataTriggerHandlerTest {
 		MetadataTriggerHandler.selector = new FakeSelector(
 			new List<SObject>{ action }
 		);
-		MetadataTriggerHandler.permissionMap = new Map<String, Boolean>{
-			BYPASS_PERMISSION => true
-		};
+		ActionUtility.userPermissions = new Set<String>{BYPASS_PERMISSION};
 
 		handler.beforeInsert(handler.triggerNew);
 


### PR DESCRIPTION
Fixes #153

Fixes an issue where including trigger action framework in a namespaced package makes custom permission checks fail if the permission is not in the same namespace.

This requires using 2 SOQL queries to connect the User to the Custom Permission. To minimize the number of queries and processing done, the following strategies were employed:
  - Blindly get ALL custom permissions assigned to the user instead of parsing through the actions and pulling out permissions to check one at a time. Then, when checking permissions, simply check if the permissions list contains the desired permission. The allows the queries for user permissions to happen exactly once.
  - Move permission checks to a dedicated, static class, that can cache and share the permission with all handlers, including finalizers, that happen in a transaction context.

Unit tests were updated to mock permissions the new way but were otherwise untouched as the goal of this change is to cause zero change in behavior or functionality.

- [X] Tests pass
- [N/A no behavior change] Appropriate changes to README are included in PR
