### PR TITLE
Bugfix: Enable nulling of fields in Flows

### DIFF
--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -253,8 +253,10 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 		sObject stateAfterFlow
 	) {
 		Boolean hasBeenMutated = false;
-		Map<String, Object> afterFlowMap = stateAfterFlow.getPopulatedFieldsAsMap();
-		for (String fieldName : afterFlowMap.keySet()) {
+		Set<String> recordPopulatedFields = new Set<String>();
+		recordPopulatedFields.addAll(stateAfterFlow.getPopulatedFieldsAsMap().keySet());
+		recordPopulatedFields.addAll(stateBeforeFlow.getPopulatedFieldsAsMap().keySet()); 
+		for (String fieldName : recordPopulatedFields) {
 			if (stateBeforeFlow.get(fieldName) != stateAfterFlow.get(fieldName)) {
 				stateBeforeFlow.put(fieldName, stateAfterFlow.get(fieldName));
 				hasBeenMutated = true;

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -22,6 +22,7 @@ private class TriggerActionFlowTest {
 	private static final String ERROR_MESSAGE_SHOULD_MATCH = 'The message should be what we expect';
 	private static final String ERROR_SHOULD_BE_ADDED = 'There should be an error added to the record';
 	private static final String ERROR_SHOULD_NOT_BE_ADDED = 'There should not be an error added to the record';
+	private static final String ERROR_NOT_NULLED_AFTER_FLOW = 'Field nulled in Flow was not written back to record variable';
 	private static final String EXCEPTION_SHOULD_BE_THROWN = 'An exception should be thrown';
 	private static final String EXCEPTION_SHOULD_HAVE_THE_CORRECT_MESSAGE = 'The exception should have the correct message';
 	private static final String EXCEPTION_SHOULD_NOT_BE_THROWN = 'There should be no exception thrown when this method is called with a valid flow.';
@@ -265,6 +266,20 @@ private class TriggerActionFlowTest {
 			false,
 			myAccount.hasErrors(),
 			ERROR_SHOULD_NOT_BE_ADDED
+		);
+	}
+
+	@IsTest
+	private static void nulledFieldInFlowShouldBeTransferredBack() {
+		myAccount.BillingStreet = TEST;
+		oldAccount.BillingStreet = TEST;
+		myAccountAfterFlow.BillingStreet = null;
+
+		actionFlow.beforeUpdate(newList, oldList);
+
+		System.Assert.isNull(
+			myAccount.BillingStreet,
+			ERROR_NOT_NULLED_AFTER_FLOW
 		);
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -270,18 +270,16 @@ private class TriggerActionFlowTest {
 	}
 
 	@IsTest
-	private static void nulledFieldInFlowShouldBeTransferredBack() {
-		myAccount.BillingStreet = TEST;
-		oldAccount.BillingStreet = TEST;
-		myAccountAfterFlow.BillingStreet = null;
+    private static void nulledFieldInFlowShouldBeTransferredBack() {
+        myAccount.BillingStreet = TEST;
+        oldAccount.BillingStreet = TEST;
+        myAccountAfterFlow = myAccount.clone(true);
+        myAccountAfterFlow.BillingStreet = null;
 
-		actionFlow.beforeUpdate(newList, oldList);
+        actionFlow.beforeUpdate(newList, oldList);
 
-		System.Assert.isNull(
-			myAccount.BillingStreet,
-			ERROR_NOT_NULLED_AFTER_FLOW
-		);
-	}
+        System.Assert.isNull(myAccount.BillingStreet, ERROR_NOT_NULLED_AFTER_FLOW);
+    }
 
 	@IsTest
 	private static void unsuccessfulActionResultShouldBeAddedAsErrorToRecord() {


### PR DESCRIPTION
Fixes #157

Hi @mitchspano, as I have said I have found out where this is coming from and have a proposed fix + corresponding test to confirm that a nulled field is now transferred over to the record after it's invoked.

If it's intended to not let nulled fields be transferred or if there is a more elegant way of going about this, I am all ears of how to accomplish this, as this was a issue I have been debugging for the past two days, thinking there is something wrong in my Flow :)

- [x] Tests pass --> I ran TriggerActionFlowTest as this is where the change lies and it's all successes.
- [x] Appropriate changes to README are included in PR --> None deemed necessary here
