### PR TITLE
Bump api

### DIFF
--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Generate Package Version
 
 on:
   workflow_dispatch:

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -6,10 +6,6 @@ on:
       packageVersion:
         required: true
         type: string
-    outputs:
-      packageId:
-        description: 04t package version id created
-        value: ${{ jobs.create-package-version.outputs.packageId }}
 
 jobs:
   create-package-version:
@@ -40,4 +36,4 @@ jobs:
         id: create
         run: |
           packageId=$(sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --package-version ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json | jq -e -r ".result.SubscriberPackageVersionId")
-          echo "packageId=$packageId" >> $GITHUB_OUTPUT
+          echo "packageId=$packageId"

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Create package version
         id: create
         run: |
-          sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --package-version ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json
+          sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --version-number ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -34,5 +34,4 @@ jobs:
       - name: Create package version
         id: create
         run: |
-          packageId=$(sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --package-version ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json | jq -e -r ".result.SubscriberPackageVersionId")
-          echo "packageId=$packageId"
+          sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --package-version ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      packageVersion:
+        required: true
+        type: string
+    outputs:
+      packageId:
+        description: 04t package version id created
+        value: ${{ jobs.create-package-version.outputs.packageId }}
+
+jobs:
+  create-package-version:
+    runs-on: ubuntu-latest
+    outputs:
+      packageId: ${{ steps.create.outputs.packageId }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ">=20"
+          cache: "npm"
+
+      - name: Install sf cli
+        run: |
+          npm install --global @salesforce/cli
+
+      - name: Authenticate into DevHub
+        run: |
+          echo "${SALESFORCE_JWT_SECRET_KEY}" > server.key
+          sf org login jwt --client-id ${{ secrets.SALESFORCE_CONSUMER_KEY }} --jwt-key-file server.key --username ${{ secrets.SALESFORCE_DEVHUB_USERNAME}} --set-default-dev-hub --alias devhub
+        env:
+          SALESFORCE_JWT_SECRET_KEY: ${{ secrets.SALESFORCE_JWT_SECRET_KEY }}
+
+      - name: Create package version
+        id: create
+        run: |
+          packageId=$(sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --package-version ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json | jq -e -r ".result.SubscriberPackageVersionId")
+          echo "packageId=$packageId" >> $GITHUB_OUTPUT

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=20"
-          cache: "npm"
 
       - name: Install sf cli
         run: |

--- a/.github/workflows/Package.yml
+++ b/.github/workflows/Package.yml
@@ -34,4 +34,4 @@ jobs:
       - name: Create package version
         id: create
         run: |
-          sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --version-number ${{ inputs.packageVersion }} --tag ${{ github.sha }} --wait 120 --code-coverage --installation-key-bypass --json
+          sf package version create --definition-file config/project-scratch-def.json --package "Trigger Actions Framework" --version-number ${{ inputs.packageVersion }} --wait 120 --code-coverage --installation-key-bypass

--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ Create a trigger action record with `Apex_Class_Name__c` equal to `TriggerAction
 Individual trigger actions can have their own dynamic entry criteria defined in a simple formula.
 This is a new feature and is built using the [`FormulaEval` namespace](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_namespace_formulaeval.htm) within Apex.
 
-#### [Entry Criteria Beta Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=08cKY000000XZBUYA4)
+#### [Entry Criteria Beta Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdYaYAK)
 
-#### [Entry Criteria Beta Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=08cKY000000XZBUYA4)
+#### [Entry Criteria Beta Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdYaYAK)
 
 ### SObject Setup
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,44 +1,45 @@
 {
-  "packageDirectories": [
-    {
-      "path": "trigger-actions-framework",
-      "default": true,
-      "package": "Trigger Actions Framework",
-      "versionName": "Version 0.3",
-      "versionNumber": "0.3.1.NEXT"
-    }
-  ],
-  "namespace": "",
-  "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "59.0",
-  "packageAliases": {
-    "Trigger Actions Framework": "0Ho3h0000008Om4CAE",
-    "Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",
-    "Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK",
-    "Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK",
-    "Trigger Actions Framework@0.1.4-0": "04t3h000004VaJWAA0",
-    "Trigger Actions Framework@0.1.4-1": "04t3h000004VaJbAAK",
-    "Trigger Actions Framework@0.1.5-0": "04t3h000004VaJqAAK",
-    "Trigger Actions Framework@0.1.6": "04t3h000004VaLDAA0",
-    "Trigger Actions Framework@0.1.7": "04t3h000004VaLIAA0",
-    "Trigger Actions Framework@0.1.8": "04t3h000004VaLNAA0",
-    "Trigger Actions Framework@0.1.9": "04t3h000004VaLSAA0",
-    "Trigger Actions Framework@0.2.0": "04t3h000004VaLmAAK",
-    "Trigger Actions Framework@0.2.1": "04t3h000004VaVFAA0",
-    "Trigger Actions Framework@0.2.2-1": "04t3h000004OYREAA4",
-    "Trigger Actions Framework@0.2.3-1": "04t3h000004OYTKAA4",
-    "Trigger Actions Framework@0.2.5-1": "04t3h000004OYUDAA4",
-    "Trigger Actions Framework@0.2.6-1": "04t3h000004juLaAAI",
-    "Trigger Actions Framework@0.2.8": "04t3h000004juLuAAI",
-    "Trigger Actions Framework@0.2.9": "04t3h000004juNCAAY",
-    "Trigger Actions Framework@0.2.9-1": "04t3h000004juNHAAY",
-    "Trigger Actions Framework@0.2.10": "04t3h000004juNRAAY",
-    "Trigger Actions Framework@0.2.11": "04tKY000000Pb8tYAC",
-    "Trigger Actions Framework@0.3.0": "04tKY000000Pb8ZYAS",
-    "Trigger Actions Framework@0.3.1-0": "04tKY000000Pd90YAC",
-    "Trigger Actions Framework@0.3.1-1": "04tKY000000Pd95YAC",
-    "Trigger Actions Framework@0.3.1-2": "04tKY000000Pd9AYAS",
-    "Trigger Actions Framework@0.3.1-3": "04tKY000000PdYBYA0",
-    "Trigger Actions Framework@0.3.1-4": "04tKY000000PdYGYA0"
-  }
+	"packageDirectories": [
+		{
+			"path": "trigger-actions-framework",
+			"default": true,
+			"package": "Trigger Actions Framework",
+			"versionName": "Version 0.3",
+			"versionNumber": "0.3.1.NEXT"
+		}
+	],
+	"namespace": "",
+	"sfdcLoginUrl": "https://login.salesforce.com",
+	"sourceApiVersion": "59.0",
+	"packageAliases": {
+		"Trigger Actions Framework": "0Ho3h0000008Om4CAE",
+		"Trigger Actions Framework@0.1.0-1": "04t3h000004VaHaAAK",
+		"Trigger Actions Framework@0.1.2": "04t3h000004VaIdAAK",
+		"Trigger Actions Framework@0.1.3": "04t3h000004VaInAAK",
+		"Trigger Actions Framework@0.1.4-0": "04t3h000004VaJWAA0",
+		"Trigger Actions Framework@0.1.4-1": "04t3h000004VaJbAAK",
+		"Trigger Actions Framework@0.1.5-0": "04t3h000004VaJqAAK",
+		"Trigger Actions Framework@0.1.6": "04t3h000004VaLDAA0",
+		"Trigger Actions Framework@0.1.7": "04t3h000004VaLIAA0",
+		"Trigger Actions Framework@0.1.8": "04t3h000004VaLNAA0",
+		"Trigger Actions Framework@0.1.9": "04t3h000004VaLSAA0",
+		"Trigger Actions Framework@0.2.0": "04t3h000004VaLmAAK",
+		"Trigger Actions Framework@0.2.1": "04t3h000004VaVFAA0",
+		"Trigger Actions Framework@0.2.2-1": "04t3h000004OYREAA4",
+		"Trigger Actions Framework@0.2.3-1": "04t3h000004OYTKAA4",
+		"Trigger Actions Framework@0.2.5-1": "04t3h000004OYUDAA4",
+		"Trigger Actions Framework@0.2.6-1": "04t3h000004juLaAAI",
+		"Trigger Actions Framework@0.2.8": "04t3h000004juLuAAI",
+		"Trigger Actions Framework@0.2.9": "04t3h000004juNCAAY",
+		"Trigger Actions Framework@0.2.9-1": "04t3h000004juNHAAY",
+		"Trigger Actions Framework@0.2.10": "04t3h000004juNRAAY",
+		"Trigger Actions Framework@0.2.11": "04tKY000000Pb8tYAC",
+		"Trigger Actions Framework@0.3.0": "04tKY000000Pb8ZYAS",
+		"Trigger Actions Framework@0.3.1-0": "04tKY000000Pd90YAC",
+		"Trigger Actions Framework@0.3.1-1": "04tKY000000Pd95YAC",
+		"Trigger Actions Framework@0.3.1-2": "04tKY000000Pd9AYAS",
+		"Trigger Actions Framework@0.3.1-3": "04tKY000000PdYBYA0",
+		"Trigger Actions Framework@0.3.1-4": "04tKY000000PdYGYA0",
+		"Trigger Actions Framework@0.3.1-5": "04tKY000000PdYaYAK"
+	}
 }

--- a/trigger-actions-framework/main/default/classes/FinalizerHandler.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FinalizerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/FinalizerHandlerTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FinalizerHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/FlowChangeEventHeader.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FlowChangeEventHeader.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/FlowChangeEventHeaderTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FlowChangeEventHeaderTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/FormulaFilter.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FormulaFilter.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerAction.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionConstants.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddError.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowAddErrorTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypass.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassProcessor.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowBypassTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowChangeEvent.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowChangeEvent.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowChangeEventTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowChangeEventTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>58.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypasses.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearAllBypassesTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypass.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowClearBypassTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassed.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowIsBypassedTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls
@@ -290,7 +290,7 @@ public inherited sharing virtual class TriggerBase {
 	}
 
 	@TestVisible
-	private virtual Integer getDmlRows() {
+	protected virtual Integer getDmlRows() {
 		return Limits.getDmlRows();
 	}
 

--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
@@ -471,7 +471,7 @@ private class TriggerBaseTest {
 			super.finalizeDmlOperation();
 			finalized = true;
 		}
-		private override Integer getDmlRows() {
+		protected override Integer getDmlRows() {
 			if (dmlRows != null) {
 				return dmlRows;
 			}

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerRecord.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerRecord.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerRecordTest.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerRecordTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>61.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
+++ b/trigger-actions-framework/main/default/classes/TriggerTestUtility.cls-meta.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>56.0</apiVersion>
+    <apiVersion>62.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Bump API version of classes to 62.
Make some minor modifications of the `TriggerBase` class to adhere to [this new behavior](https://help.salesforce.com/s/articleView?id=release-notes.rn_apex_BlockMethodOverride.htm&release=250&type=5)

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
