### PR TITLE
Refactor trigger variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Apex Trigger Actions Framework
 
-#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdZJYA0)
+#### [Unlocked Package Installation (Production)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdZOYA0)
 
-#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdZJYA0)
+#### [Unlocked Package Installation (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04tKY000000PdZOYA0)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ public class TA_Opportunity_StageInsertRules implements TriggerAction.BeforeInse
   @TestVisible
   private static final String INVALID_STAGE_INSERT_ERROR = 'The Stage must be \'Prospecting\' when an Opportunity is created';
 
-  public void beforeInsert(List<Opportunity> newList){
-    for (Opportunity opp : newList) {
+  public void beforeInsert(List<Opportunity> triggerNew){
+    for (Opportunity opp : triggerNew) {
       if (opp.StageName != PROSPECTING) {
         opp.addError(INVALID_STAGE_INSERT_ERROR);
       }
@@ -196,10 +196,10 @@ Use the `TriggerBase.idToNumberOfTimesSeenBeforeUpdate` and `TriggerBase.idToNum
 ```java
 public class TA_Opportunity_RecalculateCategory implements TriggerAction.AfterUpdate {
 
-  public void afterUpdate(List<Opportunity> newList, List<Opportunity> oldList) {
-    Map<Id,Opportunity> oldMap = new Map<Id,Opportunity>(oldList);
+  public void afterUpdate(List<Opportunity> triggerNew, List<Opportunity> triggerOld) {
+    Map<Id,Opportunity> oldMap = new Map<Id,Opportunity>(triggerOld);
     List<Opportunity> oppsToBeUpdated = new List<Opportunity>();
-    for (Opportunity opp : newList) {
+    for (Opportunity opp : triggerNew) {
       if (
         TriggerBase.idToNumberOfTimesSeenAfterUpdate.get(opp.id) == 1 &&
         opp.StageName != oldMap.get(opp.id).StageName
@@ -315,17 +315,17 @@ public class TA_Opportunity_Queries {
   public Map<Id, Account> beforeAccountMap { get; private set; }
 
   public class Service implements TriggerAction.BeforeInsert {
-    public void beforeInsert(List<Opportunity> newList) {
+    public void beforeInsert(List<Opportunity> triggerNew) {
       TA_Opportunity_Queries.getInstance().beforeAccountMap = getAccountMapFromOpportunities(
-        newList
+        triggerNew
       );
     }
 
     private Map<Id, Account> getAccountMapFromOpportunities(
-      List<Opportunity> newList
+      List<Opportunity> triggerNew
     ) {
       Set<Id> accountIds = new Set<Id>();
-      for (Opportunity myOpp : newList) {
+      for (Opportunity myOpp : triggerNew) {
         accountIds.add(myOpp.AccountId);
       }
       return new Map<Id, Account>(
@@ -344,10 +344,10 @@ With the `TA_Opportunity_Queries` class configured as the first action, all subs
 
 ```java
 public class TA_Opportunity_StandardizeName implements TriggerAction.BeforeInsert {
-  public void beforeInsert(List<Opportunity> newList) {
+  public void beforeInsert(List<Opportunity> triggerNew) {
     Map<Id, Account> accountIdToAccount = TA_Opportunity_Queries.getInstance()
       .beforeAccountMap;
-    for (Opportunity myOpp : newList) {
+    for (Opportunity myOpp : triggerNew) {
       String accountName = accountIdToAccount.get(myOpp.AccountId)?.Name;
       myOpp.Name = accountName != null
         ? accountName + ' | ' + myOpp.Name
@@ -366,12 +366,12 @@ In the example above, the top-level class is the implementation of the Singleton
 
 ## Use of Trigger Maps
 
-To avoid having to downcast from `Map<Id,sObject>`, we simply construct a new map out of our `newList` and `oldList` variables:
+To avoid having to downcast from `Map<Id,sObject>`, we simply construct a new map out of our `triggerNew` and `triggerOld` variables:
 
 ```java
-public void beforeUpdate(List<Opportunity> newList, List<Opportunity> oldList) {
-  Map<Id,Opportunity> newMap = new Map<Id,Opportunity>(newList);
-  Map<Id,Opportunity> oldMap = new Map<Id,Opportunity>(oldList);
+public void beforeUpdate(List<Opportunity> triggerNew, List<Opportunity> triggerOld) {
+  Map<Id,Opportunity> newMap = new Map<Id,Opportunity>(triggerNew);
+  Map<Id,Opportunity> oldMap = new Map<Id,Opportunity>(triggerOld);
   ...
 }
 ```
@@ -405,38 +405,38 @@ Take a look at how both of these are used in the `TA_Opportunity_StageChangeRule
 ```java
 @IsTest
 private static void invalidStageChangeShouldPreventSave() {
-  List<Opportunity> newList = new List<Opportunity>();
-  List<Opportunity> oldList = new List<Opportunity>();
+  List<Opportunity> triggerNew = new List<Opportunity>();
+  List<Opportunity> triggerOld = new List<Opportunity>();
   //generate fake Id
   Id myRecordId = TriggerTestUtility.getFakeId(Opportunity.SObjectType);
-  newList.add(
+  triggerNew.add(
     new Opportunity(
       Id = myRecordId,
       StageName = Constants.OPPORTUNITY_STAGENAME_CLOSED_WON
     )
   );
-  oldList.add(
+  triggerOld.add(
     new Opportunity(
       Id = myRecordId,
       StageName = Constants.OPPORTUNITY_STAGENAME_QUALIFICATION
     )
   );
 
-  new TA_Opportunity_StageChangeRules().beforeUpdate(newList, oldList);
+  new TA_Opportunity_StageChangeRules().beforeUpdate(triggerNew, triggerOld);
 
   //Use getErrors() SObject method to get errors from addError without performing DML
   System.assertEquals(
     true,
-    newList[0].hasErrors(),
+    triggerNew[0].hasErrors(),
     'The record should have errors'
   );
   System.assertEquals(
     1,
-    newList[0].getErrors().size(),
+    triggerNew[0].getErrors().size(),
     'There should be exactly one error'
   );
   System.assertEquals(
-    newList[0].getErrors()[0].getMessage(),
+    triggerNew[0].getErrors()[0].getMessage(),
     String.format(
       TA_Opportunity_StageChangeRules.INVALID_STAGE_CHANGE_ERROR,
       new List<String>{
@@ -499,12 +499,12 @@ Finally, use the static variables/methods of the finalizer within your trigger a
 public with sharing class TA_Opportunity_RecalculateCategory implements TriggerAction.AfterUpdate {
 
   public void afterUpdate(
-    List<Opportunity> newList,
-    List<Opportunity> oldList
+    List<Opportunity> triggerNew,
+    List<Opportunity> triggerOld
   ) {
-    Map<Id, Opportunity> oldMap = new Map<Id, Opportunity>(oldList);
+    Map<Id, Opportunity> oldMap = new Map<Id, Opportunity>(triggerOld);
     List<Opportunity> toRecalculate = new List<Opportunity>();
-    for (Opportunity opp : newList) {
+    for (Opportunity opp : triggerNew) {
       if (opp.Amount != oldMap.get(opp.Id).Amount) {
         toRecalculate.add(opp);
       }

--- a/docs/trigger-actions-framework/MetadataTriggerHandler.md
+++ b/docs/trigger-actions-framework/MetadataTriggerHandler.md
@@ -183,135 +183,135 @@ public static void clearAllBypasses()
 
 ---
 
-### `beforeInsert(newList)`
+### `beforeInsert(triggerNew)`
 
 Execute the Before Insert Trigger Actions.
 
 #### Signature
 ```apex
-public void beforeInsert(List<SObject> newList)
+public void beforeInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records being inserted. |
+| triggerNew | List&lt;SObject&gt; | The list of new records being inserted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterInsert(newList)`
+### `afterInsert(triggerNew)`
 
 Execute the After Insert Trigger Actions.
 
 #### Signature
 ```apex
-public void afterInsert(List<SObject> newList)
+public void afterInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that were inserted. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that were inserted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeUpdate(newList, oldList)`
+### `beforeUpdate(triggerNew, triggerOld)`
 
 Execute the Before Update Trigger Actions.
 
 #### Signature
 ```apex
-public void beforeUpdate(List<SObject> newList, List<SObject> oldList)
+public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of updated records. |
-| oldList | List&lt;SObject&gt; | The list of old records before the update. |
+| triggerNew | List&lt;SObject&gt; | The list of updated records. |
+| triggerOld | List&lt;SObject&gt; | The list of old records before the update. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUpdate(newList, oldList)`
+### `afterUpdate(triggerNew, triggerOld)`
 
 Execute the After Update Trigger Actions.
 
 #### Signature
 ```apex
-public void afterUpdate(List<SObject> newList, List<SObject> oldList)
+public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of updated records. |
-| oldList | List&lt;SObject&gt; | The list of old records before the update. |
+| triggerNew | List&lt;SObject&gt; | The list of updated records. |
+| triggerOld | List&lt;SObject&gt; | The list of old records before the update. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeDelete(oldList)`
+### `beforeDelete(triggerOld)`
 
 Execute the Before Delete Trigger Actions.
 
 #### Signature
 ```apex
-public void beforeDelete(List<SObject> oldList)
+public void beforeDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of records being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of records being deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterDelete(oldList)`
+### `afterDelete(triggerOld)`
 
 Execute the After Delete Trigger Actions.
 
 #### Signature
 ```apex
-public void afterDelete(List<SObject> oldList)
+public void afterDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of records that were deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of records that were deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUndelete(newList)`
+### `afterUndelete(triggerNew)`
 
 Execute the After Undelete Trigger Actions.
 
 #### Signature
 ```apex
-public void afterUndelete(List<SObject> newList)
+public void afterUndelete(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records that were undeleted. |
+| triggerNew | List&lt;SObject&gt; | The list of records that were undeleted. |
 
 #### Return Type
 **void**

--- a/docs/trigger-actions-framework/TriggerAction.md
+++ b/docs/trigger-actions-framework/TriggerAction.md
@@ -27,19 +27,19 @@ This interface defines the logic that should be executed before
 a new record is inserted.
 
 #### Methods
-##### `beforeInsert(newList)`
+##### `beforeInsert(triggerNew)`
 
 This method is called before a new record is inserted.
 
 ###### Signature
 ```apex
-public void beforeInsert(List<SObject> newList)
+public void beforeInsert(List<SObject> triggerNew)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being inserted. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being inserted. |
 
 ###### Return Type
 **void**
@@ -49,19 +49,19 @@ public void beforeInsert(List<SObject> newList)
 This interface defines the logic that should be executed after a new record is inserted.
 
 #### Methods
-##### `afterInsert(newList)`
+##### `afterInsert(triggerNew)`
 
 This method is called after a new record is inserted.
 
 ###### Signature
 ```apex
-public void afterInsert(List<SObject> newList)
+public void afterInsert(List<SObject> triggerNew)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that were inserted. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that were inserted. |
 
 ###### Return Type
 **void**
@@ -71,20 +71,20 @@ public void afterInsert(List<SObject> newList)
 This interface defines the logic that should be executed before a record is updated.
 
 #### Methods
-##### `beforeUpdate(newList, oldList)`
+##### `beforeUpdate(triggerNew, triggerOld)`
 
 This method is called before a record is updated.
 
 ###### Signature
 ```apex
-public void beforeUpdate(List<SObject> newList, List<SObject> oldList)
+public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that are being updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being updated. |
 
 ###### Return Type
 **void**
@@ -94,20 +94,20 @@ public void beforeUpdate(List<SObject> newList, List<SObject> oldList)
 This interface defines the logic that should be executed after a record is updated.
 
 #### Methods
-##### `afterUpdate(newList, oldList)`
+##### `afterUpdate(triggerNew, triggerOld)`
 
 This method is called after a record is updated.
 
 ###### Signature
 ```apex
-public void afterUpdate(List<SObject> newList, List<SObject> oldList)
+public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that were updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that were updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that were updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that were updated. |
 
 ###### Return Type
 **void**
@@ -117,19 +117,19 @@ public void afterUpdate(List<SObject> newList, List<SObject> oldList)
 This interface defines the logic that should be executed before a record is deleted.
 
 #### Methods
-##### `beforeDelete(oldList)`
+##### `beforeDelete(triggerOld)`
 
 This method is called before a record is deleted.
 
 ###### Signature
 ```apex
-public void beforeDelete(List<SObject> oldList)
+public void beforeDelete(List<SObject> triggerOld)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that are being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being deleted. |
 
 ###### Return Type
 **void**
@@ -139,19 +139,19 @@ public void beforeDelete(List<SObject> oldList)
 This interface defines the logic that should be executed after a record is deleted.
 
 #### Methods
-##### `afterDelete(oldList)`
+##### `afterDelete(triggerOld)`
 
 This method is called after a record is deleted.
 
 ###### Signature
 ```apex
-public void afterDelete(List<SObject> oldList)
+public void afterDelete(List<SObject> triggerOld)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that were deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that were deleted. |
 
 ###### Return Type
 **void**
@@ -161,19 +161,19 @@ public void afterDelete(List<SObject> oldList)
 This interface defines the logic that should be executed after a record is undeleted.
 
 #### Methods
-##### `afterUndelete(newList)`
+##### `afterUndelete(triggerNew)`
 
 This method is called after a record is undeleted.
 
 ###### Signature
 ```apex
-public void afterUndelete(List<SObject> newList)
+public void afterUndelete(List<SObject> triggerNew)
 ```
 
 ###### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that were undeleted. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that were undeleted. |
 
 ###### Return Type
 **void**

--- a/docs/trigger-actions-framework/TriggerActionFlow.md
+++ b/docs/trigger-actions-framework/TriggerActionFlow.md
@@ -137,135 +137,135 @@ IllegalArgumentException: if the bypass type is not valid.
 
 ---
 
-### `beforeInsert(newList)`
+### `beforeInsert(triggerNew)`
 
 This method executes the Flow for the specified list of records before the insert of the records.
 
 #### Signature
 ```apex
-public void beforeInsert(List<SObject> newList)
+public void beforeInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records to execute the Flow for. |
+| triggerNew | List&lt;SObject&gt; | The list of records to execute the Flow for. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterInsert(newList)`
+### `afterInsert(triggerNew)`
 
 This method executes the Flow for the specified list of records after the insert of the records.
 
 #### Signature
 ```apex
-public void afterInsert(List<SObject> newList)
+public void afterInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records to execute the Flow for. |
+| triggerNew | List&lt;SObject&gt; | The list of records to execute the Flow for. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeUpdate(newList, oldList)`
+### `beforeUpdate(triggerNew, triggerOld)`
 
 This method executes the Flow for the specified list of records before the update of the records.
 
 #### Signature
 ```apex
-public void beforeUpdate(List<SObject> newList, List<SObject> oldList)
+public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that are being updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being updated. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUpdate(newList, oldList)`
+### `afterUpdate(triggerNew, triggerOld)`
 
 This method executes the Flow for the specified list of records after the update of the records.
 
 #### Signature
 ```apex
-public void afterUpdate(List<SObject> newList, List<SObject> oldList)
+public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that are being updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being updated. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeDelete(oldList)`
+### `beforeDelete(triggerOld)`
 
 This method executes the Flow for the specified list of records before the delete of the records.
 
 #### Signature
 ```apex
-public void beforeDelete(List<SObject> oldList)
+public void beforeDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that are being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterDelete(oldList)`
+### `afterDelete(triggerOld)`
 
 This method executes the Flow for the specified list of records after the delete of the records.
 
 #### Signature
 ```apex
-public void afterDelete(List<SObject> oldList)
+public void afterDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that are being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUndelete(newList)`
+### `afterUndelete(triggerNew)`
 
 This method executes the Flow for the specified list of records before the undelete of the records.
 
 #### Signature
 ```apex
-public void afterUndelete(List<SObject> newList)
+public void afterUndelete(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records that are being restored. |
+| triggerNew | List&lt;SObject&gt; | The list of records that are being restored. |
 
 #### Return Type
 **void**

--- a/docs/trigger-actions-framework/TriggerActionFlowChangeEvent.md
+++ b/docs/trigger-actions-framework/TriggerActionFlowChangeEvent.md
@@ -151,7 +151,7 @@ IllegalArgumentException: if the bypass type is not valid.
 
 ---
 
-### `beforeInsert(newList)`
+### `beforeInsert(triggerNew)`
 
 *Inherited*
 
@@ -159,20 +159,20 @@ This method executes the Flow for the specified list of records before the inser
 
 #### Signature
 ```apex
-public void beforeInsert(List<SObject> newList)
+public void beforeInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records to execute the Flow for. |
+| triggerNew | List&lt;SObject&gt; | The list of records to execute the Flow for. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterInsert(newList)`
+### `afterInsert(triggerNew)`
 
 *Inherited*
 
@@ -180,20 +180,20 @@ This method executes the Flow for the specified list of records after the insert
 
 #### Signature
 ```apex
-public void afterInsert(List<SObject> newList)
+public void afterInsert(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records to execute the Flow for. |
+| triggerNew | List&lt;SObject&gt; | The list of records to execute the Flow for. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeUpdate(newList, oldList)`
+### `beforeUpdate(triggerNew, triggerOld)`
 
 *Inherited*
 
@@ -201,21 +201,21 @@ This method executes the Flow for the specified list of records before the updat
 
 #### Signature
 ```apex
-public void beforeUpdate(List<SObject> newList, List<SObject> oldList)
+public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that are being updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being updated. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUpdate(newList, oldList)`
+### `afterUpdate(triggerNew, triggerOld)`
 
 *Inherited*
 
@@ -223,21 +223,21 @@ This method executes the Flow for the specified list of records after the update
 
 #### Signature
 ```apex
-public void afterUpdate(List<SObject> newList, List<SObject> oldList)
+public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of new records that are being updated. |
-| oldList | List&lt;SObject&gt; | The list of old records that are being updated. |
+| triggerNew | List&lt;SObject&gt; | The list of new records that are being updated. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being updated. |
 
 #### Return Type
 **void**
 
 ---
 
-### `beforeDelete(oldList)`
+### `beforeDelete(triggerOld)`
 
 *Inherited*
 
@@ -245,20 +245,20 @@ This method executes the Flow for the specified list of records before the delet
 
 #### Signature
 ```apex
-public void beforeDelete(List<SObject> oldList)
+public void beforeDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that are being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterDelete(oldList)`
+### `afterDelete(triggerOld)`
 
 *Inherited*
 
@@ -266,20 +266,20 @@ This method executes the Flow for the specified list of records after the delete
 
 #### Signature
 ```apex
-public void afterDelete(List<SObject> oldList)
+public void afterDelete(List<SObject> triggerOld)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| oldList | List&lt;SObject&gt; | The list of old records that are being deleted. |
+| triggerOld | List&lt;SObject&gt; | The list of old records that are being deleted. |
 
 #### Return Type
 **void**
 
 ---
 
-### `afterUndelete(newList)`
+### `afterUndelete(triggerNew)`
 
 *Inherited*
 
@@ -287,13 +287,13 @@ This method executes the Flow for the specified list of records before the undel
 
 #### Signature
 ```apex
-public void afterUndelete(List<SObject> newList)
+public void afterUndelete(List<SObject> triggerNew)
 ```
 
 #### Parameters
 | Name | Type | Description |
 |------|------|-------------|
-| newList | List&lt;SObject&gt; | The list of records that are being restored. |
+| triggerNew | List&lt;SObject&gt; | The list of records that are being restored. |
 
 #### Return Type
 **void**

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -42,6 +42,7 @@
 		"Trigger Actions Framework@0.3.1-4": "04tKY000000PdYGYA0",
 		"Trigger Actions Framework@0.3.1-5": "04tKY000000PdYaYAK",
 		"Trigger Actions Framework@0.3.1-6": "04tKY000000PdZ9YAK",
-		"Trigger Actions Framework@0.3.1-7": "04tKY000000PdZJYA0"
+		"Trigger Actions Framework@0.3.1-7": "04tKY000000PdZJYA0",
+		"Trigger Actions Framework@0.3.2": "04tKY000000PdZOYA0"
 	}
 }

--- a/trigger-actions-framework/main/default/classes/FormulaFilter.cls
+++ b/trigger-actions-framework/main/default/classes/FormulaFilter.cls
@@ -62,24 +62,24 @@ global class FormulaFilter {
 	/**
 	 * @description Filters the given lists of new and old SObjects based on the entry criteria formula.
 	 *
-	 * This method evaluates the entry criteria formula for each record in the `newList` and `oldList`.
+	 * This method evaluates the entry criteria formula for each record in the `triggerNew` and `triggerOld`.
 	 * If the formula evaluates to true for a record, it is included in the filtered lists.
 	 *
-	 * @param newList The list of new SObjects to filter.
-	 * @param oldList The list of old SObjects to filter.
+	 * @param triggerNew The list of new SObjects to filter.
+	 * @param triggerOld The list of old SObjects to filter.
 	 * @return A `FormulaFilter.Result` object containing the filtered lists of new and old SObjects.
 	 */
 	public FormulaFilter.Result filterByEntryCriteria(
-		List<SObject> newList,
-		List<SObject> oldList
+		List<SObject> triggerNew,
+		List<SObject> triggerOld
 	) {
 		FormulaFilter.Result result = new FormulaFilter.Result();
 		String entryCriteriaFormula = this.triggerActionConfiguration
 			?.Entry_Criteria__c;
 
 		if (String.isBlank(entryCriteriaFormula)) {
-			result.newList = newList;
-			result.oldList = oldList;
+			result.triggerNew = triggerNew;
+			result.triggerOld = triggerOld;
 			return result;
 		}
 		String nameOfType = getNameOfType(
@@ -93,10 +93,10 @@ global class FormulaFilter {
 			nameOfType
 		);
 
-		Integer size = newList != null ? newList.size() : oldList.size();
+		Integer size = triggerNew != null ? triggerNew.size() : triggerOld.size();
 		for (Integer i = 0; i < size; i++) {
-			SObject record = newList?.get(i);
-			SObject recordPrior = oldList?.get(i);
+			SObject record = triggerNew?.get(i);
+			SObject recordPrior = triggerOld?.get(i);
 			TriggerRecord toProcess = getTriggerRecord(
 				triggerRecordSubType,
 				nameOfType
@@ -104,8 +104,8 @@ global class FormulaFilter {
 			toProcess.newSobject = record;
 			toProcess.oldSobject = recordPrior;
 			if ((Boolean) fx.evaluate(toProcess)) {
-				result.newList.add(record);
-				result.oldList.add(recordPrior);
+				result.triggerNew.add(record);
+				result.triggerOld.add(recordPrior);
 			}
 		}
 		return result;
@@ -193,15 +193,15 @@ global class FormulaFilter {
 		/**
 		 * @description The filtered list of new SObjects.
 		 */
-		public List<SObject> newList;
+		public List<SObject> triggerNew;
 		/**
 		 * @description The filtered list of old SObjects.
 		 */
-		public List<SObject> oldList;
+		public List<SObject> triggerOld;
 
 		private Result() {
-			this.newList = new List<SObject>();
-			this.oldList = new List<SObject>();
+			this.triggerNew = new List<SObject>();
+			this.triggerOld = new List<SObject>();
 		}
 	}
 }

--- a/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls
+++ b/trigger-actions-framework/main/default/classes/FormulaFilterTest.cls
@@ -20,11 +20,11 @@
 global class FormulaFilterTest {
 	private static final String ACCOUNT_SOBJECT_NAME = 'Account';
 	private static final String EXCEPTION_SHOULD_BE_THROWN = 'An exception should be thrown';
-	private static List<Account> newList = new List<Account>{
+	private static List<Account> triggerNew = new List<Account>{
 		new Account(Name = 'Test Account 1'),
 		new Account(Name = 'Test Account 2')
 	};
-	private static List<Account> oldList = new List<Account>{
+	private static List<Account> triggerOld = new List<Account>{
 		new Account(Name = 'Test Account 1'),
 		new Account(Name = 'Test Account 2')
 	};
@@ -46,19 +46,19 @@ global class FormulaFilterTest {
 		);
 
 		FormulaFilter.Result result = filter.filterByEntryCriteria(
-			newList,
-			oldList
+			triggerNew,
+			triggerOld
 		);
 
 		System.Assert.areEqual(
 			2,
-			result.newList.size(),
-			'The size of newList should be 2'
+			result.triggerNew.size(),
+			'The size of triggerNew should be 2'
 		);
 		System.Assert.areEqual(
 			2,
-			result.oldList.size(),
-			'The size of oldList should be 2'
+			result.triggerOld.size(),
+			'The size of triggerOld should be 2'
 		);
 	}
 
@@ -73,24 +73,24 @@ global class FormulaFilterTest {
 		);
 
 		FormulaFilter.Result result = filter.filterByEntryCriteria(
-			newList,
-			oldList
+			triggerNew,
+			triggerOld
 		);
 
 		System.Assert.areEqual(
 			2,
-			result.newList.size(),
-			'The size of newList should be 2'
+			result.triggerNew.size(),
+			'The size of triggerNew should be 2'
 		);
 		System.Assert.areEqual(
 			2,
-			result.oldList.size(),
-			'The size of newList should be 2'
+			result.triggerOld.size(),
+			'The size of triggerNew should be 2'
 		);
 	}
 
 	@IsTest
-	private static void validFormulaShouldFilterContentsOfNewList() {
+	private static void validFormulaShouldFilterContentsOftriggerNew() {
 		configuration.Entry_Criteria__c = 'record.Name = "Test Account 1"';
 		FormulaFilter filter = new FormulaFilter(
 			configuration,
@@ -99,29 +99,29 @@ global class FormulaFilterTest {
 		);
 
 		FormulaFilter.Result result = filter.filterByEntryCriteria(
-			newList,
-			oldList
+			triggerNew,
+			triggerOld
 		);
 
 		System.Assert.areEqual(
 			1,
-			result.newList.size(),
-			'There should be 1 record in newList'
+			result.triggerNew.size(),
+			'There should be 1 record in triggerNew'
 		);
 		System.Assert.areEqual(
 			'Test Account 1',
-			((Account) result.newList[0]).Name,
-			'The first record newList should have a name of Test Account 1'
+			((Account) result.triggerNew[0]).Name,
+			'The first record triggerNew should have a name of Test Account 1'
 		);
 		System.Assert.areEqual(
 			1,
-			result.oldList.size(),
-			'There should be 1 record in newList'
+			result.triggerOld.size(),
+			'There should be 1 record in triggerNew'
 		);
 		System.Assert.areEqual(
 			'Test Account 1',
-			((Account) result.oldList[0]).Name,
-			'The first record newList should have a name of Test Account 1'
+			((Account) result.triggerOld[0]).Name,
+			'The first record triggerNew should have a name of Test Account 1'
 		);
 	}
 
@@ -135,13 +135,19 @@ global class FormulaFilterTest {
 		);
 
 		FormulaFilter.Result result = filter.filterByEntryCriteria(
-			newList,
-			oldList
+			triggerNew,
+			triggerOld
 		);
 
 		System.Assert.isNotNull(result, 'result should not be null');
-		System.Assert.isTrue(result.newList.isEmpty(), 'newList should be empty');
-		System.Assert.isTrue(result.oldList.isEmpty(), 'oldList should be empty');
+		System.Assert.isTrue(
+			result.triggerNew.isEmpty(),
+			'triggerNew should be empty'
+		);
+		System.Assert.isTrue(
+			result.triggerOld.isEmpty(),
+			'triggerOld should be empty'
+		);
 	}
 
 	@IsTest
@@ -155,7 +161,7 @@ global class FormulaFilterTest {
 		);
 
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}
@@ -182,7 +188,7 @@ global class FormulaFilterTest {
 		);
 
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}
@@ -209,7 +215,7 @@ global class FormulaFilterTest {
 		);
 
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}
@@ -241,7 +247,7 @@ global class FormulaFilterTest {
 		);
 
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}
@@ -270,7 +276,7 @@ global class FormulaFilterTest {
 			ACCOUNT_SOBJECT_NAME
 		);
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}
@@ -300,7 +306,7 @@ global class FormulaFilterTest {
 		);
 
 		try {
-			filter.filterByEntryCriteria(newList, oldList);
+			filter.filterByEntryCriteria(triggerNew, triggerOld);
 		} catch (IllegalArgumentException e) {
 			caught = e;
 		}

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandler.cls
@@ -156,66 +156,66 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 	/**
 	 * @description Execute the Before Insert Trigger Actions.
 	 *
-	 * @param newList The list of new records being inserted.
+	 * @param triggerNew The list of new records being inserted.
 	 */
-	public void beforeInsert(List<SObject> newList) {
-		this.executeActions(TriggerOperation.BEFORE_INSERT, newList, null);
+	public void beforeInsert(List<SObject> triggerNew) {
+		this.executeActions(TriggerOperation.BEFORE_INSERT, triggerNew, null);
 	}
 
 	/**
 	 * @description Execute the After Insert Trigger Actions.
 	 *
-	 * @param newList The list of new records that were inserted.
+	 * @param triggerNew The list of new records that were inserted.
 	 */
-	public void afterInsert(List<SObject> newList) {
-		this.executeActions(TriggerOperation.AFTER_INSERT, newList, null);
+	public void afterInsert(List<SObject> triggerNew) {
+		this.executeActions(TriggerOperation.AFTER_INSERT, triggerNew, null);
 	}
 
 	/**
 	 * @description Execute the Before Update Trigger Actions.
 	 *
-	 * @param newList The list of updated records.
-	 * @param oldList The list of old records before the update.
+	 * @param triggerNew The list of updated records.
+	 * @param triggerOld The list of old records before the update.
 	 */
-	public void beforeUpdate(List<SObject> newList, List<SObject> oldList) {
-		this.executeActions(TriggerOperation.BEFORE_UPDATE, newList, oldList);
+	public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld) {
+		this.executeActions(TriggerOperation.BEFORE_UPDATE, triggerNew, triggerOld);
 	}
 
 	/**
 	 * @description Execute the After Update Trigger Actions.
 	 *
-	 * @param newList The list of updated records.
-	 * @param oldList The list of old records before the update.
+	 * @param triggerNew The list of updated records.
+	 * @param triggerOld The list of old records before the update.
 	 */
-	public void afterUpdate(List<SObject> newList, List<SObject> oldList) {
-		this.executeActions(TriggerOperation.AFTER_UPDATE, newList, oldList);
+	public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld) {
+		this.executeActions(TriggerOperation.AFTER_UPDATE, triggerNew, triggerOld);
 	}
 
 	/**
 	 * @description Execute the Before Delete Trigger Actions.
 	 *
-	 * @param oldList The list of records being deleted.
+	 * @param triggerOld The list of records being deleted.
 	 */
-	public void beforeDelete(List<SObject> oldList) {
-		this.executeActions(TriggerOperation.BEFORE_DELETE, null, oldList);
+	public void beforeDelete(List<SObject> triggerOld) {
+		this.executeActions(TriggerOperation.BEFORE_DELETE, null, triggerOld);
 	}
 
 	/**
 	 * @description Execute the After Delete Trigger Actions.
 	 *
-	 * @param oldList The list of records that were deleted.
+	 * @param triggerOld The list of records that were deleted.
 	 */
-	public void afterDelete(List<SObject> oldList) {
-		this.executeActions(TriggerOperation.AFTER_DELETE, null, oldList);
+	public void afterDelete(List<SObject> triggerOld) {
+		this.executeActions(TriggerOperation.AFTER_DELETE, null, triggerOld);
 	}
 
 	/**
 	 * @description Execute the After Undelete Trigger Actions.
 	 *
-	 * @param newList The list of records that were undeleted.
+	 * @param triggerNew The list of records that were undeleted.
 	 */
-	public void afterUndelete(List<SObject> newList) {
-		this.executeActions(TriggerOperation.AFTER_UNDELETE, newList, null);
+	public void afterUndelete(List<SObject> triggerNew) {
+		this.executeActions(TriggerOperation.AFTER_UNDELETE, triggerNew, null);
 	}
 
 	/**
@@ -351,13 +351,13 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 	 * @description Execute the Trigger Actions.
 	 *
 	 * @param context The Trigger Operation context.
-	 * @param newList The list of new records.
-	 * @param oldList The list of old records.
+	 * @param triggerNew The list of new records.
+	 * @param triggerOld The list of old records.
 	 */
 	private void executeActions(
 		TriggerOperation context,
-		List<SObject> newList,
-		List<SObject> oldList
+		List<SObject> triggerNew,
+		List<SObject> triggerOld
 	) {
 		for (Trigger_Action__mdt triggerMetadata : getActionMetadata(context)) {
 			Object triggerAction = getTriggerActionObject(context, triggerMetadata);
@@ -374,12 +374,12 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 					context,
 					this.sObjectName
 				)
-				.filterByEntryCriteria(newList, oldList);
+				.filterByEntryCriteria(triggerNew, triggerOld);
 
 			if (
 				Math.max(
-					(filtered.oldList == null) ? 0 : filtered.oldList.size(),
-					(filtered.newList == null) ? 0 : filtered.newList.size()
+					(filtered.triggerOld == null) ? 0 : filtered.triggerOld.size(),
+					(filtered.triggerNew == null) ? 0 : filtered.triggerNew.size()
 				) == 0
 			) {
 				continue;
@@ -388,31 +388,31 @@ public inherited sharing class MetadataTriggerHandler extends TriggerBase implem
 			switch on context {
 				when BEFORE_INSERT {
 					((TriggerAction.BeforeInsert) triggerAction)
-						.beforeInsert(filtered.newList);
+						.beforeInsert(filtered.triggerNew);
 				}
 				when AFTER_INSERT {
 					((TriggerAction.AfterInsert) triggerAction)
-						.afterInsert(filtered.newList);
+						.afterInsert(filtered.triggerNew);
 				}
 				when BEFORE_UPDATE {
 					((TriggerAction.BeforeUpdate) triggerAction)
-						.beforeUpdate(filtered.newList, filtered.oldList);
+						.beforeUpdate(filtered.triggerNew, filtered.triggerOld);
 				}
 				when AFTER_UPDATE {
 					((TriggerAction.AfterUpdate) triggerAction)
-						.afterUpdate(filtered.newList, filtered.oldList);
+						.afterUpdate(filtered.triggerNew, filtered.triggerOld);
 				}
 				when BEFORE_DELETE {
 					((TriggerAction.BeforeDelete) triggerAction)
-						.beforeDelete(filtered.oldList);
+						.beforeDelete(filtered.triggerOld);
 				}
 				when AFTER_DELETE {
 					((TriggerAction.AfterDelete) triggerAction)
-						.afterDelete(filtered.oldList);
+						.afterDelete(filtered.triggerOld);
 				}
 				when AFTER_UNDELETE {
 					((TriggerAction.AfterUndelete) triggerAction)
-						.afterUndelete(filtered.newList);
+						.afterUndelete(filtered.triggerNew);
 				}
 			}
 		}

--- a/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
+++ b/trigger-actions-framework/main/default/classes/MetadataTriggerHandlerTest.cls
@@ -749,37 +749,43 @@ private class MetadataTriggerHandlerTest {
 	}
 
 	public class TestBeforeInsert implements TriggerAction.BeforeInsert {
-		public void beforeInsert(List<SObject> newList) {
+		public void beforeInsert(List<SObject> triggerNew) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestAfterInsert implements TriggerAction.AfterInsert {
-		public void afterInsert(List<SObject> newList) {
+		public void afterInsert(List<SObject> triggerNew) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestBeforeUpdate implements TriggerAction.BeforeUpdate {
-		public void beforeUpdate(List<SObject> newList, List<SObject> oldList) {
+		public void beforeUpdate(
+			List<SObject> triggerNew,
+			List<SObject> triggerOld
+		) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestAfterUpdate implements TriggerAction.AfterUpdate {
-		public void afterUpdate(List<SObject> newList, List<SObject> oldList) {
+		public void afterUpdate(
+			List<SObject> triggerNew,
+			List<SObject> triggerOld
+		) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestBeforeDelete implements TriggerAction.BeforeDelete {
-		public void beforeDelete(List<SObject> oldList) {
+		public void beforeDelete(List<SObject> triggerOld) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestAfterDelete implements TriggerAction.AfterDelete {
-		public void afterDelete(List<SObject> newList) {
+		public void afterDelete(List<SObject> triggerNew) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}
 	public class TestAfterUndelete implements TriggerAction.AfterUndelete {
-		public void afterUndelete(List<SObject> newList) {
+		public void afterUndelete(List<SObject> triggerNew) {
 			MetadataTriggerHandlerTest.executed = true;
 		}
 	}

--- a/trigger-actions-framework/main/default/classes/TriggerAction.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerAction.cls
@@ -42,9 +42,9 @@ public class TriggerAction {
 		/**
 		 * @description This method is called before a new record is inserted.
 		 *
-		 * @param newList The list of new records that are being inserted.
+		 * @param triggerNew The list of new records that are being inserted.
 		 */
-		void beforeInsert(List<SObject> newList);
+		void beforeInsert(List<SObject> triggerNew);
 	}
 
 	/**
@@ -54,9 +54,9 @@ public class TriggerAction {
 		/**
 		 * @description This method is called after a new record is inserted.
 		 *
-		 * @param newList The list of new records that were inserted.
+		 * @param triggerNew The list of new records that were inserted.
 		 */
-		void afterInsert(List<SObject> newList);
+		void afterInsert(List<SObject> triggerNew);
 	}
 
 	/**
@@ -66,10 +66,10 @@ public class TriggerAction {
 		/**
 		 * @description This method is called before a record is updated.
 		 *
-		 * @param newList The list of new records that are being updated.
-		 * @param oldList The list of old records that are being updated.
+		 * @param triggerNew The list of new records that are being updated.
+		 * @param triggerOld The list of old records that are being updated.
 		 */
-		void beforeUpdate(List<SObject> newList, List<SObject> oldList);
+		void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld);
 	}
 
 	/**
@@ -79,10 +79,10 @@ public class TriggerAction {
 		/**
 		 * @description This method is called after a record is updated.
 		 *
-		 * @param newList The list of new records that were updated.
-		 * @param oldList The list of old records that were updated.
+		 * @param triggerNew The list of new records that were updated.
+		 * @param triggerOld The list of old records that were updated.
 		 */
-		void afterUpdate(List<SObject> newList, List<SObject> oldList);
+		void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld);
 	}
 
 	/**
@@ -92,9 +92,9 @@ public class TriggerAction {
 		/**
 		 * @description This method is called before a record is deleted.
 		 *
-		 * @param oldList The list of old records that are being deleted.
+		 * @param triggerOld The list of old records that are being deleted.
 		 */
-		void beforeDelete(List<SObject> oldList);
+		void beforeDelete(List<SObject> triggerOld);
 	}
 
 	/**
@@ -104,9 +104,9 @@ public class TriggerAction {
 		/**
 		 * @description This method is called after a record is deleted.
 		 *
-		 * @param oldList The list of old records that were deleted.
+		 * @param triggerOld The list of old records that were deleted.
 		 */
-		void afterDelete(List<SObject> oldList);
+		void afterDelete(List<SObject> triggerOld);
 	}
 
 	/**
@@ -116,9 +116,9 @@ public class TriggerAction {
 		/**
 		 * @description This method is called after a record is undeleted.
 		 *
-		 * @param newList The list of new records that were undeleted.
+		 * @param triggerNew The list of new records that were undeleted.
 		 */
-		void afterUndelete(List<SObject> newList);
+		void afterUndelete(List<SObject> triggerNew);
 	}
 
 	/**

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlow.cls
@@ -81,56 +81,56 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 	/**
 	 * @description This method executes the Flow for the specified list of records before the insert of the records.
 	 *
-	 * @param newList The list of records to execute the Flow for.
+	 * @param triggerNew The list of records to execute the Flow for.
 	 */
-	public void beforeInsert(List<SObject> newList) {
+	public void beforeInsert(List<SObject> triggerNew) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		List<Invocable.Action.Result> results = invokeAction(
-			getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
+			getInterviewInputs(triggerNew, TriggerActionConstants.RECORD_VARIABLE)
 		);
-		handleInvocableResults(results, newList);
-		applyFieldValuesDuringBefore(results, newList);
+		handleInvocableResults(results, triggerNew);
+		applyFieldValuesDuringBefore(results, triggerNew);
 	}
 
 	/**
 	 * @description This method executes the Flow for the specified list of records after the insert of the records.
 	 *
-	 * @param newList The list of records to execute the Flow for.
+	 * @param triggerNew The list of records to execute the Flow for.
 	 */
-	public void afterInsert(List<SObject> newList) {
+	public void afterInsert(List<SObject> triggerNew) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
 			invokeAction(
-				getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
+				getInterviewInputs(triggerNew, TriggerActionConstants.RECORD_VARIABLE)
 			),
-			newList
+			triggerNew
 		);
 	}
 
 	/**
 	 * @description This method executes the Flow for the specified list of records before the update of the records.
 	 *
-	 * @param newList The list of new records that are being updated.
-	 * @param oldList The list of old records that are being updated.
+	 * @param triggerNew The list of new records that are being updated.
+	 * @param triggerOld The list of old records that are being updated.
 	 */
-	public void beforeUpdate(List<SObject> newList, List<SObject> oldList) {
+	public void beforeUpdate(List<SObject> triggerNew, List<SObject> triggerOld) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
 		List<sObject> oldRecordsNotYetProcessed = new List<sObject>();
-		for (Integer i = 0; i < newList.size(); i++) {
-			sObject record = newList[i];
+		for (Integer i = 0; i < triggerNew.size(); i++) {
+			sObject record = triggerNew[i];
 			if (
 				TriggerBase.idToNumberOfTimesSeenBeforeUpdate.get(record.id) == 1 ||
 				(allowRecursion == true)
 			) {
 				recordsNotYetProcessed.add(record);
-				oldRecordsNotYetProcessed.add(oldList[i]);
+				oldRecordsNotYetProcessed.add(triggerOld[i]);
 			}
 		}
 		if (recordsNotYetProcessed.isEmpty()) {
@@ -146,23 +146,23 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 	/**
 	 * @description This method executes the Flow for the specified list of records after the update of the records.
 	 *
-	 * @param newList The list of new records that are being updated.
-	 * @param oldList The list of old records that are being updated.
+	 * @param triggerNew The list of new records that are being updated.
+	 * @param triggerOld The list of old records that are being updated.
 	 */
-	public void afterUpdate(List<SObject> newList, List<SObject> oldList) {
+	public void afterUpdate(List<SObject> triggerNew, List<SObject> triggerOld) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		List<sObject> recordsNotYetProcessed = new List<sObject>();
 		List<sObject> oldRecordsNotYetProcessed = new List<sObject>();
-		for (Integer i = 0; i < newList.size(); i++) {
-			sObject record = newList[i];
+		for (Integer i = 0; i < triggerNew.size(); i++) {
+			sObject record = triggerNew[i];
 			if (
 				TriggerBase.idToNumberOfTimesSeenAfterUpdate.get(record.id) == 1 ||
 				(allowRecursion == true)
 			) {
 				recordsNotYetProcessed.add(record);
-				oldRecordsNotYetProcessed.add(oldList[i]);
+				oldRecordsNotYetProcessed.add(triggerOld[i]);
 			}
 		}
 		if (recordsNotYetProcessed.isEmpty()) {
@@ -179,57 +179,57 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 	/**
 	 * @description This method executes the Flow for the specified list of records before the delete of the records.
 	 *
-	 * @param oldList The list of old records that are being deleted.
+	 * @param triggerOld The list of old records that are being deleted.
 	 */
-	public void beforeDelete(List<SObject> oldList) {
+	public void beforeDelete(List<SObject> triggerOld) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
 			invokeAction(
 				getInterviewInputs(
-					oldList,
+					triggerOld,
 					TriggerActionConstants.RECORD_PRIOR_VARIABLE
 				)
 			),
-			oldList
+			triggerOld
 		);
 	}
 
 	/**
 	 * @description This method executes the Flow for the specified list of records after the delete of the records.
 	 *
-	 * @param oldList The list of old records that are being deleted.
+	 * @param triggerOld The list of old records that are being deleted.
 	 */
-	public void afterDelete(List<SObject> oldList) {
+	public void afterDelete(List<SObject> triggerOld) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
 			invokeAction(
 				getInterviewInputs(
-					oldList,
+					triggerOld,
 					TriggerActionConstants.RECORD_PRIOR_VARIABLE
 				)
 			),
-			oldList
+			triggerOld
 		);
 	}
 
 	/**
 	 * @description This method executes the Flow for the specified list of records before the undelete of the records.
 	 *
-	 * @param newList The list of records that are being restored.
+	 * @param triggerNew The list of records that are being restored.
 	 */
-	public void afterUndelete(List<SObject> newList) {
+	public void afterUndelete(List<SObject> triggerNew) {
 		if (flowIsBypassed()) {
 			return;
 		}
 		handleInvocableResults(
 			invokeAction(
-				getInterviewInputs(newList, TriggerActionConstants.RECORD_VARIABLE)
+				getInterviewInputs(triggerNew, TriggerActionConstants.RECORD_VARIABLE)
 			),
-			newList
+			triggerNew
 		);
 	}
 
@@ -254,8 +254,12 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 	) {
 		Boolean hasBeenMutated = false;
 		Set<String> recordPopulatedFields = new Set<String>();
-		recordPopulatedFields.addAll(stateAfterFlow.getPopulatedFieldsAsMap().keySet());
-		recordPopulatedFields.addAll(stateBeforeFlow.getPopulatedFieldsAsMap().keySet()); 
+		recordPopulatedFields.addAll(
+			stateAfterFlow.getPopulatedFieldsAsMap().keySet()
+		);
+		recordPopulatedFields.addAll(
+			stateBeforeFlow.getPopulatedFieldsAsMap().keySet()
+		);
 		for (String fieldName : recordPopulatedFields) {
 			if (stateBeforeFlow.get(fieldName) != stateAfterFlow.get(fieldName)) {
 				stateBeforeFlow.put(fieldName, stateAfterFlow.get(fieldName));
@@ -283,18 +287,18 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 	/**
 	 * @description This method gets the interview inputs for the specified list of new and old records.
 	 *
-	 * @param newList The list of new records.
-	 * @param oldList The list of old records.
+	 * @param triggerNew The list of new records.
+	 * @param triggerOld The list of old records.
 	 * @return A list of interview inputs.
 	 */
 	private List<Map<String, Object>> getInterviewInputs(
-		List<SObject> newList,
-		List<SObject> oldList
+		List<SObject> triggerNew,
+		List<SObject> triggerOld
 	) {
 		List<Map<String, Object>> result = new List<Map<String, Object>>();
-		for (Integer i = 0; i < newList.size(); i++) {
-			SObject oldRecord = oldList[i];
-			SObject newRecord = newList[i];
+		for (Integer i = 0; i < triggerNew.size(); i++) {
+			SObject oldRecord = triggerOld[i];
+			SObject newRecord = triggerNew[i];
 			result.add(
 				new Map<String, Object>{
 					TriggerActionConstants.RECORD_PRIOR_VARIABLE => oldRecord,
@@ -318,7 +322,7 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 
 	private void applyFieldValuesDuringBefore(
 		List<Invocable.Action.Result> results,
-		List<SObject> newList
+		List<SObject> triggerNew
 	) {
 		for (Integer i = 0; i < results.size(); i++) {
 			Invocable.Action.Result result = results[i];
@@ -330,7 +334,7 @@ public virtual inherited sharing class TriggerActionFlow implements TriggerActio
 						this.flowName + ': ' + RECORD_VARIABLE_NOT_FOUND_ERROR
 					);
 				}
-				applyFlowValues(newList[i], newRecordWhenFlowIsComplete);
+				applyFlowValues(triggerNew[i], newRecordWhenFlowIsComplete);
 			}
 		}
 	}

--- a/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerActionFlowTest.cls
@@ -44,8 +44,8 @@ private class TriggerActionFlowTest {
 		Id = myAccount.Id
 	);
 	private static Account myAccountAfterFlow = myAccount.clone(true);
-	private static List<SObject> newList = new List<SObject>{ myAccount };
-	private static List<SObject> oldList = new List<SObject>{ oldAccount };
+	private static List<SObject> triggerNew = new List<SObject>{ myAccount };
+	private static List<SObject> triggerOld = new List<SObject>{ oldAccount };
 	private static TriggerActionFlow actionFlow;
 	private static Exception myException;
 
@@ -74,13 +74,13 @@ private class TriggerActionFlowTest {
 		TriggerActionFlow.bypass(SAMPLE_FLOW_NAME);
 
 		try {
-			actionFlow.beforeInsert(newList);
-			actionFlow.afterInsert(newList);
-			actionFlow.beforeUpdate(newList, oldList);
-			actionFlow.afterUpdate(newList, oldList);
-			actionFlow.beforeDelete(oldList);
-			actionFlow.afterDelete(oldList);
-			actionFlow.afterUndelete(oldList);
+			actionFlow.beforeInsert(triggerNew);
+			actionFlow.afterInsert(triggerNew);
+			actionFlow.beforeUpdate(triggerNew, triggerOld);
+			actionFlow.afterUpdate(triggerNew, triggerOld);
+			actionFlow.beforeDelete(triggerOld);
+			actionFlow.afterDelete(triggerOld);
+			actionFlow.afterUndelete(triggerOld);
 		} catch (Exception e) {
 			myException = e;
 		}
@@ -114,7 +114,7 @@ private class TriggerActionFlowTest {
 		actionFlow.flowName = null;
 
 		try {
-			actionFlow.beforeInsert(newList);
+			actionFlow.beforeInsert(triggerNew);
 		} catch (Exception e) {
 			myException = e;
 		}
@@ -130,7 +130,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void beforeInsertShouldSucceed() {
-		actionFlow.beforeInsert(newList);
+		actionFlow.beforeInsert(triggerNew);
 
 		System.Assert.areEqual(FOO, myAccount.Name, NAME_SET_FROM_FLOW);
 		System.Assert.areEqual(true, myAccount.hasErrors(), ERROR_SHOULD_BE_ADDED);
@@ -144,7 +144,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void afterInsertShouldSucceed() {
-		actionFlow.afterInsert(newList);
+		actionFlow.afterInsert(triggerNew);
 
 		System.Assert.areEqual(
 			false,
@@ -155,7 +155,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void beforeUpdateShouldSucceed() {
-		actionFlow.beforeUpdate(newList, oldList);
+		actionFlow.beforeUpdate(triggerNew, triggerOld);
 
 		System.Assert.areEqual(FOO, myAccount.Name, NAME_SET_FROM_FLOW);
 		System.Assert.areEqual(true, myAccount.hasErrors(), ERROR_SHOULD_BE_ADDED);
@@ -169,17 +169,17 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void beforeUpdateWithNoRecordsToProcessShouldSucceed() {
-		newList.clear();
-		oldList.clear();
+		triggerNew.clear();
+		triggerOld.clear();
 
-		actionFlow.beforeUpdate(newList, oldList);
+		actionFlow.beforeUpdate(triggerNew, triggerOld);
 
 		System.Assert.areEqual(MY_ACCOUNT, myAccount.Name, NAME_SHOULD_REMAIN_SAME);
 	}
 
 	@IsTest
 	private static void afterUpdateShouldSucceed() {
-		actionFlow.afterUpdate(newList, oldList);
+		actionFlow.afterUpdate(triggerNew, triggerOld);
 
 		System.Assert.areEqual(
 			false,
@@ -190,10 +190,10 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void afterUpdateWithNoRecordsToProcessShouldSucceed() {
-		newList.clear();
-		oldList.clear();
+		triggerNew.clear();
+		triggerOld.clear();
 
-		actionFlow.afterUpdate(newList, oldList);
+		actionFlow.afterUpdate(triggerNew, triggerOld);
 
 		System.Assert.areEqual(
 			false,
@@ -204,7 +204,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void beforeDeleteShouldSucceed() {
-		actionFlow.beforeDelete(oldList);
+		actionFlow.beforeDelete(triggerOld);
 
 		System.Assert.areEqual(
 			false,
@@ -215,7 +215,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void afterDeleteShouldSucceed() {
-		actionFlow.afterDelete(oldList);
+		actionFlow.afterDelete(triggerOld);
 
 		System.Assert.areEqual(
 			false,
@@ -226,7 +226,7 @@ private class TriggerActionFlowTest {
 
 	@IsTest
 	private static void afterUndeleteShouldSucceed() {
-		actionFlow.afterUndelete(oldList);
+		actionFlow.afterUndelete(triggerOld);
 
 		System.Assert.areEqual(
 			false,
@@ -240,7 +240,7 @@ private class TriggerActionFlowTest {
 		successResult.getOutputParameters().clear();
 
 		try {
-			actionFlow.beforeInsert(newList);
+			actionFlow.beforeInsert(triggerNew);
 		} catch (IllegalArgumentException e) {
 			myException = e;
 		}
@@ -260,7 +260,7 @@ private class TriggerActionFlowTest {
 		successResult.getOutputParameters()
 			.put(TriggerActionConstants.RECORD_VARIABLE, myAccount);
 
-		actionFlow.beforeInsert(newList);
+		actionFlow.beforeInsert(triggerNew);
 
 		System.Assert.areEqual(
 			false,
@@ -270,16 +270,16 @@ private class TriggerActionFlowTest {
 	}
 
 	@IsTest
-    private static void nulledFieldInFlowShouldBeTransferredBack() {
-        myAccount.BillingStreet = TEST;
-        oldAccount.BillingStreet = TEST;
-        myAccountAfterFlow = myAccount.clone(true);
-        myAccountAfterFlow.BillingStreet = null;
+	private static void nulledFieldInFlowShouldBeTransferredBack() {
+		myAccount.BillingStreet = TEST;
+		oldAccount.BillingStreet = TEST;
+		myAccountAfterFlow = myAccount.clone(true);
+		myAccountAfterFlow.BillingStreet = null;
 
-        actionFlow.beforeUpdate(newList, oldList);
+		actionFlow.beforeUpdate(triggerNew, triggerOld);
 
-        System.Assert.isNull(myAccount.BillingStreet, ERROR_NOT_NULLED_AFTER_FLOW);
-    }
+		System.Assert.isNull(myAccount.BillingStreet, ERROR_NOT_NULLED_AFTER_FLOW);
+	}
 
 	@IsTest
 	private static void unsuccessfulActionResultShouldBeAddedAsErrorToRecord() {
@@ -304,7 +304,7 @@ private class TriggerActionFlowTest {
 			}
 		);
 
-		actionFlow.beforeInsert(newList);
+		actionFlow.beforeInsert(triggerNew);
 
 		System.Assert.areEqual(true, myAccount.hasErrors(), ERROR_SHOULD_BE_ADDED);
 		System.Assert.areEqual(1, myAccount.getErrors().size(), ONE_ERROR);

--- a/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBaseTest.cls
@@ -446,25 +446,31 @@ private class TriggerBaseTest {
 		public Boolean executed = false;
 		public Boolean finalized = false;
 		public Integer dmlRows;
-		public void beforeInsert(List<SObject> newList) {
+		public void beforeInsert(List<SObject> triggerNew) {
 			this.executed = true;
 		}
-		public void afterInsert(List<SObject> newList) {
+		public void afterInsert(List<SObject> triggerNew) {
 			this.executed = true;
 		}
-		public void beforeUpdate(List<SObject> newList, List<SObject> oldList) {
+		public void beforeUpdate(
+			List<SObject> triggerNew,
+			List<SObject> triggerOld
+		) {
 			this.executed = true;
 		}
-		public void afterUpdate(List<SObject> newList, List<SObject> oldList) {
+		public void afterUpdate(
+			List<SObject> triggerNew,
+			List<SObject> triggerOld
+		) {
 			this.executed = true;
 		}
-		public void beforeDelete(List<SObject> oldList) {
+		public void beforeDelete(List<SObject> triggerOld) {
 			this.executed = true;
 		}
-		public void afterDelete(List<SObject> newList) {
+		public void afterDelete(List<SObject> triggerNew) {
 			this.executed = true;
 		}
-		public void afterUndelete(List<SObject> newList) {
+		public void afterUndelete(List<SObject> triggerNew) {
 			this.executed = true;
 		}
 		public override void finalizeDmlOperation() {


### PR DESCRIPTION
Refactor `newList` and `oldList` to `triggerNew` and `triggerOld` to be explicit about their contents and avoid encoding variable type within the variable's name.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
