### PR TITLE
Add Bypass_Execution__c field to Trigger Action related lists

### DIFF
--- a/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
+++ b/trigger-actions-framework/main/default/layouts/sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml
@@ -98,6 +98,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.Before_Insert__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -109,6 +110,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.After_Insert__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -120,6 +122,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.Before_Update__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -131,6 +134,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.After_Update__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -142,6 +146,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.Before_Delete__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -153,6 +158,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.After_Delete__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>
@@ -164,6 +170,7 @@
         <fields>Entry_Criteria__c</fields>
         <fields>Description__c</fields>
         <fields>Order__c</fields>
+        <fields>Bypass_Execution__c</fields>
         <relatedList>Trigger_Action__mdt.After_Undelete__c</relatedList>
         <sortField>Order__c</sortField>
         <sortOrder>Asc</sortOrder>


### PR DESCRIPTION
## Summary
- Added `Bypass_Execution__c` field to all 7 Trigger Action related lists in the sObject Trigger Setting layout
- Improves visibility of active/inactive trigger actions in the Automation Studio view
- Provides better overview for administrators managing trigger action execution

## Changes Made
- Updated `sObject_Trigger_Setting__mdt-sObject Trigger Setting Layout.layout-meta.xml`
- Added `<fields>Bypass_Execution__c</fields>` to all trigger context related lists:
  - Before_Insert
  - After_Insert  
  - Before_Update
  - After_Update
  - Before_Delete
  - After_Delete
  - After_Undelete

## Test plan
- [ ] Deploy to test org and verify Bypass_Execution__c field appears in all related lists
- [ ] Confirm related lists maintain proper sorting by Order__c
- [ ] Validate UI layout displays correctly with the new field

Resolves #141

🤖 Generated with [Claude Code](https://claude.ai/code)