### PR TITLE
metadata field fieldManageability set to SubscriberControlled

### DIFF
--- a/trigger-actions-framework/main/default/classes/TriggerBase.cls
+++ b/trigger-actions-framework/main/default/classes/TriggerBase.cls
@@ -30,7 +30,7 @@
  * - A way to now finalize the DML operation.
  * ---
  * To use the `TriggerBase` class, you must create a subclass that implements the `TriggerAction` interface.
- * The `TriggerAction` interface defines the methods that should be implemented by trigger actions.
+ * The `TriggerAction` interface defines the methods that should be implemented by trigger actions. 
  */
 @SuppressWarnings(
 	'PMD.StdCyclomaticComplexity,PMD.CyclomaticComplexity,PMD.CognitiveComplexity,PMD.PropertyNamingConventions'

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -4,7 +4,7 @@
     <defaultValue>false</defaultValue>
     <description>Set this to true to bypass this Trigger Action from being called</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
     <label>Bypass Execution</label>
     <type>Checkbox</type>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Bypass_Permission__c</fullName>
     <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>
     <length>255</length>

--- a/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/DML_Finalizer__mdt/fields/Required_Permission__c.field-meta.xml
@@ -3,7 +3,7 @@
     <fullName>Required_Permission__c</fullName>
     <description>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>
     <length>255</length>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -5,7 +5,7 @@
     <description
 	>Set this to true to bypass this Trigger Action from being called</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Set this to true to bypass this Trigger Action from being called</inlineHelpText>
     <label>Bypass Execution</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>

--- a/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/Trigger_Action__mdt/fields/Required_Permission__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will  only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Execution__c.field-meta.xml
@@ -5,7 +5,7 @@
     <description
 	>Set this to true to bypass all Trigger Actions from being called on this sObject</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Set this to true to bypass all Trigger Actions from being called on this sObject</inlineHelpText>
     <label>Bypass Execution</label>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Bypass_Permission__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will be bypassed if the running user has the custom permission identified.</inlineHelpText>
     <label>Bypass Permission</label>

--- a/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
+++ b/trigger-actions-framework/main/default/objects/sObject_Trigger_Setting__mdt/fields/Required_Permission__c.field-meta.xml
@@ -4,7 +4,7 @@
     <description
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</description>
     <externalId>false</externalId>
-    <fieldManageability>DeveloperControlled</fieldManageability>
+    <fieldManageability>SubscriberControlled</fieldManageability>
     <inlineHelpText
 	>Optional. Enter the API name of a permission. If this field has a value, then the triggers on this object will only execute if the running user has the custom permission identified.</inlineHelpText>
     <label>Required Permission</label>


### PR DESCRIPTION
If TAF is used in a managed package the metadata items cannot be disabled or bypassed in installed orgs. As all metadata fields are set as `DeveloperControlled` 

This PR updates key control fields to be `SubscriberControlled` allowing installed orgs to bypass, or configure the permissions. 

Changing `DeveloperControlled` to `SubscriberControlled` will not impact any existing package usage. However, do note if you have included it in a managed package any installed orgs will not get the new metadata config. Only fresh installs would have these fields as `SubscriberControlled`

It is possibly better to change all fields to `SubscriberControlled` to avoid issues since there is no official managed package


> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
